### PR TITLE
docs: remove the redundant Katra heading from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
   <img src="docs/brand/katra-logo.svg" alt="Katra" width="360">
 </p>
 
-# Katra
-
 Katra is an open source, graph-native AI workspace for conversations, tasks, and collaborative intelligence.
 
 > [!WARNING]


### PR DESCRIPTION
## Summary

- remove the redundant `# Katra` heading from the README
- keep the logo at the top and preserve the header spacing

## Testing

- not run as part of opening this pull request

Closes #43
