### PR TITLE
docs: add a pull request template with required issue references

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,33 @@
+## Summary
+
+- describe the change at a high level
+- call out any important implementation choices or tradeoffs
+
+## Related Issues
+
+Use a closing keyword when appropriate.
+
+- Closes #
+- Related to #
+
+## Testing
+
+- [ ] Not run
+- [ ] Tests added
+- [ ] Tests updated
+- [ ] Existing tests pass
+
+Notes:
+
+- describe what you ran, what you verified, or why testing was skipped
+
+## Docs Impact
+
+- [ ] None
+- [ ] README updated
+- [ ] Docs updated
+- [ ] Follow-up docs issue opened
+
+Notes:
+
+- describe any user-facing documentation impact or link the follow-up issue


### PR DESCRIPTION
## Summary

- add a repository pull request template under `.github`
- require issue references and prompt for closing keywords
- include sections for testing notes and docs impact

## Testing

- not run as part of opening this pull request

Closes #17
