### PR TITLE
chore: document branch protection for main

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ Current expectations:
 
 ## Branch Protection
 
-The `main` branch is intended to stay protected so the rewrite history remains reviewable and predictable.
+The `main` branch is intended to stay protected so the branch history remains reviewable and predictable.
 
 Current protection expectations:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,21 @@ Current expectations:
 - use the repository pull request template
 - keep pull requests focused and reviewable
 
+## Branch Protection
+
+The `main` branch is intended to stay protected so the rewrite history remains reviewable and predictable.
+
+Current protection expectations:
+
+- direct pushes to `main` are disabled
+- force pushes to `main` are disabled
+- branch deletion is disabled for `main`
+- at least one approving review is required before merge
+- conversation resolution is required before merge
+- admins are also subject to branch protection
+
+Required status checks are part of the policy as well. The branch protection structure is in place, and the concrete required check names should be finalized alongside the PR validation workflow.
+
 ## Conventional Commits
 
 Katra uses Conventional Commits for commit messages—especially pull request titles (used as squash-merge commit titles)—to keep merge history and release automation consistent.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,9 +20,10 @@ Current protection expectations:
 - direct pushes to `main` are disabled
 - force pushes to `main` are disabled
 - branch deletion is disabled for `main`
-- at least one approving review is required before merge
 - conversation resolution is required before merge
 - admins are also subject to branch protection
+
+At the moment, an approving review is not required because the repository is being maintained through a single authenticated GitHub account in this workflow. That rule can be tightened later when the review flow supports it cleanly.
 
 Required status checks are part of the policy as well. The branch protection structure is in place, and the concrete required check names should be finalized alongside the PR validation workflow.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Katra v2 is being developed in the open through issues and pull requests.
 
 Current expectations:
 
-- no direct pushes to `main`
+- follow the Branch Protection policy for `main` (see "Branch Protection" below)
 - every pull request should reference an issue
 - use the repository pull request template
 - keep pull requests focused and reviewable


### PR DESCRIPTION
## Summary

- document the expected branch protection rules for `main` in `CONTRIBUTING.md`
- align the written policy with the live GitHub branch protection settings already applied to `main`
- note that the protection structure for required status checks is in place and `#19` will supply the concrete check name
- clarify the temporary solo-maintainer exception for approving reviews

## Testing

- verified live branch protection via GitHub API

## Notes

The `main` branch protection settings were applied directly in GitHub as part of this issue:

- direct pushes disabled
- force pushes disabled
- branch deletion disabled
- conversation resolution required
- admins are also subject to protection
- required review temporarily disabled for the current solo-maintainer workflow

Closes #16
