### PR TITLE
ci: add a pull request validation workflow

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -1,0 +1,60 @@
+name: PR Validation
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          extensions: sqlite3, pdo_sqlite
+          coverage: none
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: vendor
+          key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+
+      - name: Install Composer dependencies
+        run: composer install --no-interaction --no-progress --prefer-dist
+
+      - name: Install Node dependencies
+        run: npm ci
+
+      - name: Prepare application environment
+        run: |
+          cp .env.example .env
+          php artisan key:generate --ansi
+
+      - name: Validate Composer configuration
+        run: composer validate --no-check-publish
+
+      - name: Check code style with Pint
+        run: vendor/bin/pint --test
+
+      - name: Run Pest test suite
+        run: php artisan test
+
+      - name: Build frontend assets
+        run: npm run build

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -10,9 +10,6 @@ permissions:
 jobs:
   validate:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        php-version: ['8.3', '8.4']
 
     steps:
       - name: Checkout
@@ -21,7 +18,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php-version }}
+          php-version: '8.4'
           extensions: sqlite3, pdo_sqlite
           coverage: none
 

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -10,6 +10,9 @@ permissions:
 jobs:
   validate:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php-version: ['8.3', '8.4']
 
     steps:
       - name: Checkout
@@ -18,7 +21,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.4'
+          php-version: ${{ matrix.php-version }}
           extensions: sqlite3, pdo_sqlite
           coverage: none
 

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: '8.4'
           extensions: sqlite3, pdo_sqlite
           coverage: none
 

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -28,13 +28,8 @@ jobs:
           node-version: '22'
           cache: npm
 
-      - name: Cache Composer dependencies
-        uses: actions/cache@v4
-        with:
-          path: vendor
-          key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-composer-
+      - name: Validate Composer configuration
+        run: composer validate --no-check-publish
 
       - name: Install Composer dependencies
         run: composer install --no-interaction --no-progress --prefer-dist
@@ -46,9 +41,6 @@ jobs:
         run: |
           cp .env.example .env
           php artisan key:generate --ansi
-
-      - name: Validate Composer configuration
-        run: composer validate --no-check-publish
 
       - name: Check code style with Pint
         run: vendor/bin/pint --test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ Current protection expectations:
 
 At the moment, an approving review is not required because the repository is being maintained through a single authenticated GitHub account in this workflow. That rule can be tightened later when the review flow supports it cleanly.
 
-Required status checks are part of the policy as well. The branch protection structure is in place, and the concrete required check names should be finalized alongside the PR validation workflow.
+Required status checks are part of the policy as well. The current required status check for pull requests is `validate`, provided by the `PR Validation` GitHub Actions workflow.
 
 ## Conventional Commits
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ Current protection expectations:
 
 At the moment, an approving review is not required because the repository is being maintained through a single authenticated GitHub account in this workflow. That rule can be tightened later when the review flow supports it cleanly.
 
-Required status checks are part of the policy as well. The current required status check for pull requests is `validate`, provided by the `PR Validation` GitHub Actions workflow.
+Required status checks are part of the policy as well. The current required status check for pull requests is the GitHub Actions check labeled `PR Validation / validate` (workflow name + job name) as shown in the branch protection settings and in the PR Checks tab.
 
 ## Conventional Commits
 


### PR DESCRIPTION
## Summary

- add a GitHub Actions pull request validation workflow
- validate Composer metadata, Pint formatting, Pest tests, and the frontend build
- keep the initial CI baseline lean and leave Larastan as a follow-up issue

## Testing

- `composer validate --no-check-publish`
- `vendor/bin/pint --test`
- `php artisan test`
- `npm run build`

## Notes

Larastan follow-up issue: #50

Closes #19
