### PR TITLE
ci: automate version tags and GitHub releases

### DIFF
--- a/.github/workflows/release-tagging.yml
+++ b/.github/workflows/release-tagging.yml
@@ -1,0 +1,142 @@
+name: Release Tagging
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+env:
+  RELEASE_FLOOR_TAG: v2.0.0
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine next release tag
+        id: version
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          latest_tag=$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-version:refname | head -n 1)
+
+          if [[ -n "$latest_tag" ]]; then
+            range="${latest_tag}..HEAD"
+          else
+            latest_tag='v0.0.0'
+            range='HEAD'
+          fi
+
+          bump_level=0
+          breaking_type_pattern='^[a-z]+!:'
+          breaking_scope_pattern='^[a-z]+\([^)]+\)!:'
+          minor_pattern='^feat(\([^)]+\))?:'
+          patch_pattern='^(fix|perf)(\([^)]+\))?:'
+
+          while IFS= read -r commit; do
+            [[ -n "$commit" ]] || continue
+
+            message=$(git show -s --format=%B "$commit")
+            subject=$(printf '%s\n' "$message" | sed -n '1p')
+            conventional_line="$subject"
+
+            if [[ "$subject" =~ ^Merge\ pull\ request\ #[0-9]+ ]]; then
+              conventional_line=$(printf '%s\n' "$message" | awk 'NR > 1 && NF { print; exit }')
+            fi
+
+            conventional_line=$(printf '%s' "$conventional_line" | tr -d '\r')
+
+            if [[ -z "$conventional_line" ]]; then
+              continue
+            fi
+
+            if printf '%s' "$message" | grep -Eq '(^|[[:space:]])BREAKING CHANGE:' || [[ "$conventional_line" =~ $breaking_type_pattern ]] || [[ "$conventional_line" =~ $breaking_scope_pattern ]]; then
+              bump_level=3
+              break
+            fi
+
+            if [[ "$conventional_line" =~ $minor_pattern ]]; then
+              if (( bump_level < 2 )); then
+                bump_level=2
+              fi
+
+              continue
+            fi
+
+            if [[ "$conventional_line" =~ $patch_pattern ]] && (( bump_level < 1 )); then
+              bump_level=1
+            fi
+          done < <(git rev-list --first-parent --reverse "$range")
+
+          if (( bump_level == 0 )); then
+            echo "should_tag=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          current_version=${latest_tag#v}
+          IFS='.' read -r major minor patch <<< "$current_version"
+
+          case "$bump_level" in
+            3)
+              major=$((major + 1))
+              minor=0
+              patch=0
+              bump_name='major'
+              ;;
+            2)
+              minor=$((minor + 1))
+              patch=0
+              bump_name='minor'
+              ;;
+            1)
+              patch=$((patch + 1))
+              bump_name='patch'
+              ;;
+          esac
+
+          next_tag="v${major}.${minor}.${patch}"
+          floor_tag="${RELEASE_FLOOR_TAG}"
+
+          if ! git tag --list "${floor_tag}" | grep -q .; then
+            floor_version=${floor_tag#v}
+            IFS='.' read -r floor_major floor_minor floor_patch <<< "$floor_version"
+
+            if (( major < floor_major )) || (( major == floor_major && minor < floor_minor )) || (( major == floor_major && minor == floor_minor && patch < floor_patch )); then
+              next_tag="${floor_tag}"
+              bump_name='major'
+            fi
+          fi
+
+          if git rev-parse --verify --quiet "refs/tags/${next_tag}" >/dev/null; then
+            echo "should_tag=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "should_tag=true" >> "$GITHUB_OUTPUT"
+          echo "current_tag=${latest_tag}" >> "$GITHUB_OUTPUT"
+          echo "tag=${next_tag}" >> "$GITHUB_OUTPUT"
+          echo "bump=${bump_name}" >> "$GITHUB_OUTPUT"
+
+      - name: Create release tag
+        if: steps.version.outputs.should_tag == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
+          tag='${{ steps.version.outputs.tag }}'
+
+          git tag -a "$tag" -m "Release $tag"
+          git push origin "refs/tags/$tag"

--- a/.github/workflows/release-tagging.yml
+++ b/.github/workflows/release-tagging.yml
@@ -9,6 +9,10 @@ on:
 env:
   RELEASE_FLOOR_TAG: v2.0.0
 
+concurrency:
+  group: release-tagging-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
 
@@ -28,7 +32,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          latest_tag=$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-version:refname | head -n 1)
+          latest_tag=$(git tag --merged HEAD --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-version:refname | head -n 1)
 
           if [[ -n "$latest_tag" ]]; then
             range="${latest_tag}..HEAD"
@@ -137,6 +141,13 @@ jobs:
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
 
           tag='${{ steps.version.outputs.tag }}'
+
+          git fetch --force --tags origin
+
+          if git rev-parse --verify --quiet "refs/tags/$tag" >/dev/null; then
+            echo "Tag $tag already exists."
+            exit 0
+          fi
 
           git tag -a "$tag" -m "Release $tag"
           git push origin "refs/tags/$tag"

--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -22,14 +22,16 @@ jobs:
           set -euo pipefail
 
           if [[ ! "$TAG" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
-            echo "Unsupported tag format: $TAG" >&2
-            exit 1
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
 
+          echo "should_release=true" >> "$GITHUB_OUTPUT"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "version=${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.${BASH_REMATCH[3]}" >> "$GITHUB_OUTPUT"
 
       - name: Create or update GitHub release
+        if: steps.version.outputs.should_release == 'true'
         uses: actions/github-script@v7
         env:
           RELEASE_TAG: ${{ steps.version.outputs.tag }}
@@ -46,7 +48,6 @@ jobs:
               owner,
               repo,
               tag_name: tag,
-              target_commitish: context.sha,
             });
 
             try {
@@ -81,7 +82,6 @@ jobs:
                 body: notes.data.body,
                 draft: false,
                 prerelease: false,
-                target_commitish: context.sha,
               });
 
               console.log(`Created GitHub release for ${tag} (${version}).`);

--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -1,0 +1,88 @@
+name: Tagged Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Derive release version from tag
+        id: version
+        shell: bash
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          if [[ ! "$TAG" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+            echo "Unsupported tag format: $TAG" >&2
+            exit 1
+          fi
+
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.${BASH_REMATCH[3]}" >> "$GITHUB_OUTPUT"
+
+      - name: Create or update GitHub release
+        uses: actions/github-script@v7
+        env:
+          RELEASE_TAG: ${{ steps.version.outputs.tag }}
+          RELEASE_VERSION: ${{ steps.version.outputs.version }}
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const tag = process.env.RELEASE_TAG;
+            const version = process.env.RELEASE_VERSION;
+            const releaseName = `Katra ${tag}`;
+
+            const notes = await github.rest.repos.generateReleaseNotes({
+              owner,
+              repo,
+              tag_name: tag,
+              target_commitish: context.sha,
+            });
+
+            try {
+              const existing = await github.rest.repos.getReleaseByTag({
+                owner,
+                repo,
+                tag,
+              });
+
+              await github.rest.repos.updateRelease({
+                owner,
+                repo,
+                release_id: existing.data.id,
+                tag_name: tag,
+                name: releaseName,
+                body: notes.data.body,
+                draft: false,
+                prerelease: false,
+              });
+
+              console.log(`Updated GitHub release for ${tag} (${version}).`);
+            } catch (error) {
+              if (error.status !== 404) {
+                throw error;
+              }
+
+              await github.rest.repos.createRelease({
+                owner,
+                repo,
+                tag_name: tag,
+                name: releaseName,
+                body: notes.data.body,
+                draft: false,
+                prerelease: false,
+                target_commitish: context.sha,
+              });
+
+              console.log(`Created GitHub release for ${tag} (${version}).`);
+            }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,11 +81,13 @@ Because Katra intends to automate version bumps and releases from merges to `mai
 
 Current policy:
 
-- prefer squash merges into `main`
 - the pull request title should follow Conventional Commits
 - the final merged commit on `main` should clearly describe the released change
 
-In practice, this means the pull request title matters. If a PR is squash-merged, the squash commit title should remain a valid conventional commit.
+In practice, this means the pull request title matters. Release automation reads the first-parent history on `main`.
+
+- for GitHub merge commits, the workflow reads the first non-empty conventional commit line in the merge commit message, which should match the pull request title
+- for squash merges, the squash commit title should remain a valid conventional commit
 
 ## Semantic Versioning
 
@@ -130,8 +132,9 @@ Target behavior:
 - a pull request is merged into `main`
 - release automation evaluates the conventional commit on `main`
 - the next semantic version is calculated automatically
+- because `v1.0.0` preserves the original prototype, the v2 rewrite line on `main` floors its first automated product release at `v2.0.0`
 - a tag in `vX.Y.Z` format is created automatically
-- a GitHub release is created from that tag automatically
+- a separate tagged-release workflow creates or updates the GitHub release from that tag automatically
 
 This means contributors should think of pull request titles and merge commits as release inputs, not just review labels.
 


### PR DESCRIPTION
## Summary

- add a `Release Tagging` workflow that evaluates first-parent `main` history, calculates the next semantic version, and pushes a release tag only for qualifying conventional commits
- add a separate `Tagged Release` workflow that creates or updates the GitHub release from semantic version tags using generated release notes
- document the merge-title parsing behavior and establish a `v2.0.0` floor so the rewrite line releases on `v2.*` instead of continuing the preserved `v1.0.0` prototype series

## Related Issues

- Closes #20
- Related to #19

## Testing

- [x] Not run
- [ ] Tests added
- [ ] Tests updated
- [ ] Existing tests pass

Notes:

- validated both workflow files as YAML
- ran `git diff --check`
- dry-ran the tagging logic against current history to confirm recent `docs` / `chore` / `ci` merges do not emit a release tag
- verified the new release floor upgrades a pre-`v2` computed version to `v2.0.0`

## Docs Impact

- [ ] None
- [ ] README updated
- [x] Docs updated
- [ ] Follow-up docs issue opened

Notes:

- updated `CONTRIBUTING.md` to describe how release automation reads merge history on `main` and why the first rewrite-line product release is floored at `v2.0.0`
