### PR TITLE
fix(ci): publish releases for automated tags

### DIFF
--- a/.github/workflows/release-tagging.yml
+++ b/.github/workflows/release-tagging.yml
@@ -33,6 +33,7 @@ jobs:
           set -euo pipefail
 
           latest_tag=$(git tag --merged HEAD --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-version:refname | head -n 1)
+          head_tag=$(git tag --points-at HEAD --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-version:refname | head -n 1)
 
           if [[ -n "$latest_tag" ]]; then
             range="${latest_tag}..HEAD"
@@ -83,7 +84,15 @@ jobs:
           done < <(git rev-list --first-parent --reverse "$range")
 
           if (( bump_level == 0 )); then
+            if [[ -n "$head_tag" ]]; then
+              echo "should_tag=false" >> "$GITHUB_OUTPUT"
+              echo "should_release=true" >> "$GITHUB_OUTPUT"
+              echo "tag=${head_tag}" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+
             echo "should_tag=false" >> "$GITHUB_OUTPUT"
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -123,10 +132,13 @@ jobs:
 
           if git rev-parse --verify --quiet "refs/tags/${next_tag}" >/dev/null; then
             echo "should_tag=false" >> "$GITHUB_OUTPUT"
+            echo "should_release=true" >> "$GITHUB_OUTPUT"
+            echo "tag=${next_tag}" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           echo "should_tag=true" >> "$GITHUB_OUTPUT"
+          echo "should_release=true" >> "$GITHUB_OUTPUT"
           echo "current_tag=${latest_tag}" >> "$GITHUB_OUTPUT"
           echo "tag=${next_tag}" >> "$GITHUB_OUTPUT"
           echo "bump=${bump_name}" >> "$GITHUB_OUTPUT"
@@ -153,7 +165,7 @@ jobs:
           git push origin "refs/tags/$tag"
 
       - name: Create or update GitHub release
-        if: steps.version.outputs.should_tag == 'true'
+        if: steps.version.outputs.should_release == 'true'
         uses: actions/github-script@v7
         env:
           RELEASE_TAG: ${{ steps.version.outputs.tag }}

--- a/.github/workflows/release-tagging.yml
+++ b/.github/workflows/release-tagging.yml
@@ -151,3 +151,58 @@ jobs:
 
           git tag -a "$tag" -m "Release $tag"
           git push origin "refs/tags/$tag"
+
+      - name: Create or update GitHub release
+        if: steps.version.outputs.should_tag == 'true'
+        uses: actions/github-script@v7
+        env:
+          RELEASE_TAG: ${{ steps.version.outputs.tag }}
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const tag = process.env.RELEASE_TAG;
+            const releaseName = `Katra ${tag}`;
+
+            const notes = await github.rest.repos.generateReleaseNotes({
+              owner,
+              repo,
+              tag_name: tag,
+            });
+
+            try {
+              const existing = await github.rest.repos.getReleaseByTag({
+                owner,
+                repo,
+                tag,
+              });
+
+              await github.rest.repos.updateRelease({
+                owner,
+                repo,
+                release_id: existing.data.id,
+                tag_name: tag,
+                name: releaseName,
+                body: notes.data.body,
+                draft: false,
+                prerelease: false,
+              });
+
+              console.log(`Updated GitHub release for ${tag}.`);
+            } catch (error) {
+              if (error.status !== 404) {
+                throw error;
+              }
+
+              await github.rest.repos.createRelease({
+                owner,
+                repo,
+                tag_name: tag,
+                name: releaseName,
+                body: notes.data.body,
+                draft: false,
+                prerelease: false,
+              });
+
+              console.log(`Created GitHub release for ${tag}.`);
+            }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,7 +134,8 @@ Target behavior:
 - the next semantic version is calculated automatically
 - because `v1.0.0` preserves the original prototype, the v2 rewrite line on `main` floors its first automated product release at `v2.0.0`
 - a tag in `vX.Y.Z` format is created automatically
-- a separate tagged-release workflow creates or updates the GitHub release from that tag automatically
+- the release-tagging workflow creates or updates the GitHub release from the automated tag, including generated release notes
+- the separate tagged-release workflow remains available for semantic version tags that are pushed manually outside the main release automation flow
 
 This means contributors should think of pull request titles and merge commits as release inputs, not just review labels.
 


### PR DESCRIPTION
## Summary

- update `Release Tagging` so it creates or updates the GitHub Release with generated notes immediately after publishing an automated semver tag
- keep the separate `Tagged Release` workflow as a fallback path for semantic version tags pushed manually outside the main release automation flow
- document the corrected behavior in `CONTRIBUTING.md`

## Related Issues

- Closes #55
- Related to #20
- Related to #22

## Testing

- [ ] Not run
- [ ] Tests added
- [ ] Tests updated
- [x] Existing tests pass

Notes:

- validated both workflow files as YAML
- ran `git diff --check`
- repaired the already-missing `v2.0.0` GitHub Release manually with generated notes after confirming the automated tag existed but no downstream release workflow had run

## Docs Impact

- [ ] None
- [ ] README updated
- [x] Docs updated
- [ ] Follow-up docs issue opened

Notes:

- updated `CONTRIBUTING.md` so the documented release path matches the actual automation design
