### PR TITLE
chore: add surrealdb connectivity spike

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,3 +69,13 @@ NATIVEPHP_APP_ID=io.devoption.katra
 NATIVEPHP_APP_AUTHOR=DevOption
 NATIVEPHP_APP_DESCRIPTION="Katra is an open source, graph-native AI workspace for conversations, tasks, and collaborative intelligence."
 NATIVEPHP_APP_WEBSITE=https://github.com/devoption/katra
+
+SURREAL_BINARY=surreal
+SURREAL_HOST=127.0.0.1
+SURREAL_PORT=18001
+SURREAL_USER=root
+SURREAL_PASS=root
+SURREAL_NAMESPACE=katra
+SURREAL_DATABASE=workspace
+SURREAL_STORAGE_ENGINE=surrealkv
+# SURREAL_STORAGE_PATH=

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@
 /public/storage
 /storage/*.key
 /storage/pail
+/history.txt
 /vendor
 Homestead.json
 Homestead.yaml

--- a/app/Console/Commands/SurrealProbeCommand.php
+++ b/app/Console/Commands/SurrealProbeCommand.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Services\Surreal\SurrealCliClient;
+use Illuminate\Console\Attributes\Description;
+use Illuminate\Console\Attributes\Signature;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+use RuntimeException;
+
+#[Signature('surreal:probe {--port= : Override the local SurrealDB port} {--path= : Override the local SurrealDB datastore path} {--keep-server : Leave the started SurrealDB process running after the probe}')]
+#[Description('Start a local SurrealDB process and prove a Laravel write/read round-trip against it.')]
+class SurrealProbeCommand extends Command
+{
+    public function __construct(
+        private readonly SurrealCliClient $client,
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        if (! $this->client->isAvailable()) {
+            $this->components->error('Unable to find the `surreal` CLI. Install it first or set SURREAL_BINARY to the executable path.');
+
+            return self::FAILURE;
+        }
+
+        $host = (string) config('surreal.host');
+        $port = (int) ($this->option('port') ?: config('surreal.port'));
+        $bindAddress = sprintf('%s:%d', $host, $port);
+        $endpoint = sprintf('ws://%s', $bindAddress);
+        $storagePath = (string) ($this->option('path') ?: config('surreal.storage_path'));
+        $storageEngine = (string) config('surreal.storage_engine');
+        $username = (string) config('surreal.username');
+        $password = (string) config('surreal.password');
+        $namespace = (string) config('surreal.namespace');
+        $database = (string) config('surreal.database');
+        $recordId = 'probe:'.Str::lower(Str::random(12));
+
+        File::ensureDirectoryExists(dirname($storagePath));
+
+        $server = $this->client->startLocalServer(
+            bindAddress: $bindAddress,
+            datastorePath: $storagePath,
+            username: $username,
+            password: $password,
+            storageEngine: $storageEngine,
+        );
+
+        try {
+            if (! $this->client->waitUntilReady($endpoint)) {
+                throw new RuntimeException(sprintf('SurrealDB did not become ready on %s.', $endpoint));
+            }
+
+            $results = $this->client->runQuery(
+                endpoint: $endpoint,
+                namespace: $namespace,
+                database: $database,
+                username: $username,
+                password: $password,
+                query: sprintf(
+                    "CREATE ONLY %s CONTENT { issue: 23, mode: 'local-process', status: 'ok' };\nSELECT * FROM %s;",
+                    $recordId,
+                    $recordId,
+                ),
+            );
+
+            $createdRecord = is_array($results[0] ?? null) ? (($results[0] ?? [])[0] ?? null) : null;
+            $selectedRecords = is_array($results[1] ?? null) ? (($results[1] ?? [])[0] ?? null) : null;
+            $selectedRecord = is_array($selectedRecords) ? ($selectedRecords[0] ?? null) : null;
+
+            if (! is_array($createdRecord) || ! is_array($selectedRecord) || ($selectedRecord['id'] ?? null) !== $recordId) {
+                throw new RuntimeException('The SurrealDB probe did not return the expected write/read payload.');
+            }
+
+            $this->components->info(sprintf('Started local SurrealDB on %s', $endpoint));
+            $this->line(sprintf('Datastore: %s://%s', $storageEngine, $storagePath));
+            $this->line(sprintf('Created record: %s', $createdRecord['id']));
+            $this->line(sprintf('Read record status: %s', $selectedRecord['status'] ?? 'missing'));
+            $this->warn('Embedded verdict: Laravel can drive a local-first SurrealDB child process, but true in-process embedded PHP support remains unproven in this spike.');
+
+            if ($this->option('keep-server')) {
+                $this->line('The local SurrealDB process is still running because --keep-server was set.');
+            }
+
+            return self::SUCCESS;
+        } finally {
+            if (! $this->option('keep-server')) {
+                $server->stop(1);
+            }
+        }
+    }
+}

--- a/app/Console/Commands/SurrealProbeCommand.php
+++ b/app/Console/Commands/SurrealProbeCommand.php
@@ -30,9 +30,22 @@ class SurrealProbeCommand extends Command
 
         $host = (string) config('surreal.host');
         $port = (int) ($this->option('port') ?: config('surreal.port'));
+        $storagePath = trim((string) ($this->option('path') ?: config('surreal.storage_path')));
+
+        if ($port < 1 || $port > 65535) {
+            $this->components->error('The SurrealDB port must be between 1 and 65535.');
+
+            return self::FAILURE;
+        }
+
+        if ($storagePath === '') {
+            $this->components->error('The SurrealDB storage path must not be empty.');
+
+            return self::FAILURE;
+        }
+
         $bindAddress = sprintf('%s:%d', $host, $port);
         $endpoint = sprintf('ws://%s', $bindAddress);
-        $storagePath = (string) ($this->option('path') ?: config('surreal.storage_path'));
         $storageEngine = (string) config('surreal.storage_engine');
         $username = (string) config('surreal.username');
         $password = (string) config('surreal.password');

--- a/app/Services/Surreal/SurrealCliClient.php
+++ b/app/Services/Surreal/SurrealCliClient.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace App\Services\Surreal;
+
+use JsonException;
+use RuntimeException;
+use Symfony\Component\Process\ExecutableFinder;
+use Symfony\Component\Process\Process;
+
+class SurrealCliClient
+{
+    public function __construct(
+        private readonly ?string $configuredBinary = null,
+    ) {}
+
+    public function isAvailable(): bool
+    {
+        return $this->binary() !== null;
+    }
+
+    public function startLocalServer(string $bindAddress, string $datastorePath, string $username, string $password, string $storageEngine): Process
+    {
+        $process = new Process([
+            $this->requireBinary(),
+            'start',
+            '--bind',
+            $bindAddress,
+            '--user',
+            $username,
+            '--pass',
+            $password,
+            '--no-banner',
+            sprintf('%s://%s', $storageEngine, $datastorePath),
+        ], base_path());
+
+        $process->setTimeout(null);
+        $process->start();
+
+        return $process;
+    }
+
+    public function waitUntilReady(string $endpoint, int $attempts = 20, int $sleepMilliseconds = 250): bool
+    {
+        for ($attempt = 0; $attempt < $attempts; $attempt++) {
+            $process = new Process([
+                $this->requireBinary(),
+                'is-ready',
+                '--endpoint',
+                $endpoint,
+            ], base_path());
+
+            $process->run();
+
+            if ($process->isSuccessful()) {
+                return true;
+            }
+
+            usleep($sleepMilliseconds * 1000);
+        }
+
+        return false;
+    }
+
+    /**
+     * @return array<int, mixed>
+     */
+    public function runQuery(string $endpoint, string $namespace, string $database, string $username, string $password, string $query): array
+    {
+        $process = new Process([
+            $this->requireBinary(),
+            'sql',
+            '--endpoint',
+            $endpoint,
+            '--username',
+            $username,
+            '--password',
+            $password,
+            '--auth-level',
+            'root',
+            '--namespace',
+            $namespace,
+            '--database',
+            $database,
+            '--json',
+            '--hide-welcome',
+        ], base_path());
+
+        $process->setInput($query);
+        $process->run();
+
+        if (! $process->isSuccessful()) {
+            throw new RuntimeException(trim($process->getErrorOutput()) ?: 'Failed to execute the SurrealDB probe query.');
+        }
+
+        return $this->decodeJsonOutput($process->getOutput());
+    }
+
+    public function binary(): ?string
+    {
+        $binary = $this->configuredBinary ?: (string) config('surreal.binary', 'surreal');
+
+        if (is_file($binary) && is_executable($binary)) {
+            return $binary;
+        }
+
+        return (new ExecutableFinder)->find($binary);
+    }
+
+    /**
+     * @return array<int, mixed>
+     */
+    private function decodeJsonOutput(string $output): array
+    {
+        $decodedResults = [];
+
+        foreach (preg_split('/\R/', $output) ?: [] as $line) {
+            $trimmedLine = trim($line);
+
+            if ($trimmedLine === '') {
+                continue;
+            }
+
+            $jsonPayload = preg_replace('/^[^\[]*/', '', $trimmedLine);
+
+            if (! is_string($jsonPayload) || $jsonPayload === '' || ! str_starts_with($jsonPayload, '[')) {
+                continue;
+            }
+
+            try {
+                $decodedResults[] = json_decode($jsonPayload, true, 512, JSON_THROW_ON_ERROR);
+            } catch (JsonException $exception) {
+                throw new RuntimeException('Unable to decode the SurrealDB CLI response.', previous: $exception);
+            }
+        }
+
+        if ($decodedResults === []) {
+            throw new RuntimeException('Unable to locate JSON output in the SurrealDB CLI response.');
+        }
+
+        return $decodedResults;
+    }
+
+    private function requireBinary(): string
+    {
+        $binary = $this->binary();
+
+        if ($binary === null) {
+            throw new RuntimeException('Unable to find the `surreal` CLI. Install it or set SURREAL_BINARY to the executable path.');
+        }
+
+        return $binary;
+    }
+}

--- a/app/Services/Surreal/SurrealCliClient.php
+++ b/app/Services/Surreal/SurrealCliClient.php
@@ -89,7 +89,15 @@ class SurrealCliClient
         $process->run();
 
         if (! $process->isSuccessful()) {
-            throw new RuntimeException(trim($process->getErrorOutput()) ?: 'Failed to execute the SurrealDB probe query.');
+            $stderr = trim($process->getErrorOutput());
+            $stdout = trim($process->getOutput());
+            $details = array_filter([
+                sprintf('exit code %d', $process->getExitCode() ?? 1),
+                $stderr !== '' ? sprintf('stderr: %s', $stderr) : null,
+                $stdout !== '' ? sprintf('stdout: %s', $stdout) : null,
+            ]);
+
+            throw new RuntimeException('Failed to execute the SurrealDB probe query ('.implode('; ', $details).').');
         }
 
         return $this->decodeJsonOutput($process->getOutput());

--- a/config/surreal.php
+++ b/config/surreal.php
@@ -1,0 +1,32 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | SurrealDB Spike Configuration
+    |--------------------------------------------------------------------------
+    |
+    | This spike proves a local-first SurrealDB flow by starting a local
+    | SurrealDB process and then driving it from Laravel via the `surreal`
+    | CLI. It does not prove true in-process embedded PHP support.
+    |
+    */
+
+    'binary' => env('SURREAL_BINARY', 'surreal'),
+
+    'host' => env('SURREAL_HOST', '127.0.0.1'),
+
+    'port' => (int) env('SURREAL_PORT', 18001),
+
+    'username' => env('SURREAL_USER', 'root'),
+
+    'password' => env('SURREAL_PASS', 'root'),
+
+    'namespace' => env('SURREAL_NAMESPACE', 'katra'),
+
+    'database' => env('SURREAL_DATABASE', 'workspace'),
+
+    'storage_engine' => env('SURREAL_STORAGE_ENGINE', 'surrealkv'),
+
+    'storage_path' => env('SURREAL_STORAGE_PATH', storage_path('app/surrealdb/dev')),
+];

--- a/tests/Feature/SurrealConnectivitySpikeTest.php
+++ b/tests/Feature/SurrealConnectivitySpikeTest.php
@@ -3,6 +3,7 @@
 use App\Services\Surreal\SurrealCliClient;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
+use Tests\TestCase;
 
 it('proves a local surrealdb write and read flow from laravel', function () {
     $client = app(SurrealCliClient::class);
@@ -22,11 +23,7 @@ it('proves a local surrealdb write and read flow from laravel', function () {
     File::deleteDirectory($storagePath);
 
     try {
-        $this->artisan('surreal:probe')
-            ->expectsOutputToContain('Started local SurrealDB on')
-            ->expectsOutputToContain('Created record:')
-            ->expectsOutputToContain('Embedded verdict:')
-            ->assertExitCode(0);
+        retryProbeAssertion($this);
     } finally {
         File::deleteDirectory($storagePath);
     }
@@ -55,4 +52,27 @@ function reserveFreePort(): int
     }
 
     return $port;
+}
+
+function retryProbeAssertion(TestCase $testCase, int $attempts = 3): void
+{
+    $lastException = null;
+
+    for ($attempt = 1; $attempt <= $attempts; $attempt++) {
+        config()->set('surreal.port', reserveFreePort());
+
+        try {
+            $testCase->artisan('surreal:probe')
+                ->expectsOutputToContain('Started local SurrealDB on')
+                ->expectsOutputToContain('Created record:')
+                ->expectsOutputToContain('Embedded verdict:')
+                ->assertExitCode(0);
+
+            return;
+        } catch (Throwable $exception) {
+            $lastException = $exception;
+        }
+    }
+
+    throw $lastException ?? new RuntimeException('The SurrealDB probe did not complete successfully.');
 }

--- a/tests/Feature/SurrealConnectivitySpikeTest.php
+++ b/tests/Feature/SurrealConnectivitySpikeTest.php
@@ -1,0 +1,58 @@
+<?php
+
+use App\Services\Surreal\SurrealCliClient;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+
+it('proves a local surrealdb write and read flow from laravel', function () {
+    $client = app(SurrealCliClient::class);
+
+    if (! $client->isAvailable()) {
+        $this->markTestSkipped('The `surreal` CLI is not available in this environment.');
+    }
+
+    $storagePath = storage_path('app/surrealdb/test-'.Str::uuid());
+
+    config()->set('surreal.host', '127.0.0.1');
+    config()->set('surreal.port', reserveFreePort());
+    config()->set('surreal.storage_path', $storagePath);
+    config()->set('surreal.namespace', 'katra');
+    config()->set('surreal.database', 'spike');
+
+    File::deleteDirectory($storagePath);
+
+    try {
+        $this->artisan('surreal:probe')
+            ->expectsOutputToContain('Started local SurrealDB on')
+            ->expectsOutputToContain('Created record:')
+            ->expectsOutputToContain('Embedded verdict:')
+            ->assertExitCode(0);
+    } finally {
+        File::deleteDirectory($storagePath);
+    }
+});
+
+function reserveFreePort(): int
+{
+    $socket = stream_socket_server('tcp://127.0.0.1:0', $errorCode, $errorMessage);
+
+    if ($socket === false) {
+        throw new RuntimeException(sprintf('Unable to reserve a free TCP port: %s (%d)', $errorMessage, $errorCode));
+    }
+
+    $address = stream_socket_get_name($socket, false);
+
+    fclose($socket);
+
+    if ($address === false) {
+        throw new RuntimeException('Unable to determine the reserved TCP port.');
+    }
+
+    $port = (int) ltrim((string) strrchr($address, ':'), ':');
+
+    if ($port <= 0) {
+        throw new RuntimeException(sprintf('Unable to parse the reserved TCP port from [%s].', $address));
+    }
+
+    return $port;
+}


### PR DESCRIPTION
## Summary

- add a `surreal:probe` Artisan command that starts a local `surrealkv://`-backed SurrealDB process and proves a write/read round-trip from Laravel
- add spike configuration and example environment variables for the local SurrealDB process
- add a focused Pest feature test that exercises the probe when the `surreal` CLI is available

## Caveat

This spike proves a local-first child-process flow from Laravel. It does **not** prove true in-process embedded SurrealDB support from PHP, and the command/test output call that out explicitly.

## Verification

- vendor/bin/pint --dirty --format agent
- php artisan surreal:probe --port=18004 --path="$(pwd)/storage/app/surrealdb/manual-probe-2"
- php artisan test --compact --filter=surreal
- php artisan test --compact
- git diff --check

Refs #23