### PR TITLE
fix(ci): use a supported macOS runner label

### DIFF
--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -130,7 +130,7 @@ jobs:
       - context
       - release
     if: needs.context.outputs.should_release == 'true'
-    runs-on: macos-13
+    runs-on: macos-15-intel
     env:
       GH_TOKEN: ${{ github.token }}
       GITHUB_TOKEN: ${{ github.token }}
@@ -210,7 +210,7 @@ jobs:
           {
             echo "## macOS Packaging"
             echo
-            echo "- Runner: \`macos-13\`"
+            echo "- Runner: \`macos-15-intel\`"
             echo "- Architecture: \`x64\`"
             echo "- Release tag: \`${{ needs.context.outputs.tag }}\`"
             echo


### PR DESCRIPTION
## Summary

- switch the tagged release packaging job from `macos-13` to `macos-15-intel`
- keep the packaging target aligned with the existing `x64` desktop artifact build
- update the workflow summary output to match the new runner label

## Why

The latest release job failed with:

- `The configuration 'macos-13-us-default' is not supported`

Using the current Intel macOS runner label should restore the packaging path for release builds.

## Verification

- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/tagged-release.yml'); puts 'yaml ok'"
- git diff --check