### PR TITLE
chore: add the GitHub issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/general.yml
+++ b/.github/ISSUE_TEMPLATE/general.yml
@@ -1,0 +1,43 @@
+name: General Issue
+description: Track a scoped piece of work using Katra's standard issue structure.
+title: ""
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for product, architecture, CI, docs, design, and repository work.
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Start with "As a <role>, I need..."
+      placeholder: |
+        As a <role>, I need...
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance_criteria
+    attributes:
+      label: Acceptance Criteria
+      description: List the outcomes that must be true before the issue is done.
+      value: |
+        - [ ] ...
+    validations:
+      required: true
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes
+      description: Optional details, implementation constraints, references, or edge cases.
+      placeholder: Optional details, implementation constraints, references, or edge cases.
+    validations:
+      required: false
+  - type: textarea
+    id: out_of_scope
+    attributes:
+      label: Out of Scope
+      description: Optional. Explicitly excluded from this issue.
+      placeholder: Optional. Explicitly excluded from this issue.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/general.yml
+++ b/.github/ISSUE_TEMPLATE/general.yml
@@ -11,9 +11,9 @@ body:
     id: context
     attributes:
       label: Context
-      description: Start with "As a <role>, I need..."
+      description: Start with "As a `<role>`, I need..."
       placeholder: |
-        As a <role>, I need...
+        As a `<role>`, I need...
     validations:
       required: true
   - type: textarea

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,7 @@ Katra v2 is being developed in the open through issues and pull requests.
 
 Current expectations:
 
+- open new work through the repository issue form
 - follow the Branch Protection policy for `main` (see "Branch Protection" below)
 - every pull request should reference an issue
 - use the repository pull request template


### PR DESCRIPTION
## Summary

- add a GitHub issue form that matches Katra's standard issue structure
- disable blank issues so new work defaults into the repository form
- note the issue form expectation in CONTRIBUTING.md

## Related Issues

Closes #75

## Testing

- [x] Not run
- [ ] Tests added
- [ ] Tests updated
- [ ] Existing tests pass

Notes:

- validated the issue template YAML loads successfully
- ran `git diff --check`

## Docs Impact

- [x] None
- [ ] README updated
- [ ] Docs updated
- [ ] Follow-up docs issue opened

Notes:

- CONTRIBUTING.md was updated only to reflect the repository workflow expectation
