### PR TITLE
fix: restore the GitHub issue form

### DIFF
--- a/.github/ISSUE_TEMPLATE/general.yml
+++ b/.github/ISSUE_TEMPLATE/general.yml
@@ -1,7 +1,5 @@
 name: General Issue
 description: Track a scoped piece of work using Katra's standard issue structure.
-title: ""
-labels: []
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
## Summary

- remove invalid empty metadata from the general issue form
- restore a valid template so the GitHub new-issue flow can render again

## Related Issues

Closes #77

## Testing

- [x] Not run
- [ ] Tests added
- [ ] Tests updated
- [ ] Existing tests pass

Notes:

- validated the issue form YAML loads successfully
- ran `git diff --check`
- aligned the form with GitHub's issue-form syntax guidance for optional top-level fields

## Docs Impact

- [x] None
- [ ] README updated
- [ ] Docs updated
- [ ] Follow-up docs issue opened

Notes:

- no user-facing docs changes were needed for this repair
