### PR TITLE
ci: build Apple Silicon macOS release artifacts

### DIFF
--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -130,7 +130,15 @@ jobs:
       - context
       - release
     if: needs.context.outputs.should_release == 'true'
-    runs-on: macos-15-intel
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - architecture: x64
+            runner: macos-15-intel
+          - architecture: arm64
+            runner: macos-15
+    runs-on: ${{ matrix.runner }}
     env:
       GH_TOKEN: ${{ github.token }}
       GITHUB_TOKEN: ${{ github.token }}
@@ -174,13 +182,50 @@ jobs:
         run: php artisan native:install --force --no-interaction
 
       - name: Build macOS desktop artifact
-        run: php artisan native:build mac x64 --no-interaction
+        run: php artisan native:build mac ${{ matrix.architecture }} --no-interaction
+
+      - name: Stage architecture-specific release assets
+        run: |
+          set -euo pipefail
+
+          mkdir -p nativephp/electron/release-assets
+          shopt -s nullglob
+
+          staged_files=0
+
+          for candidate in nativephp/electron/dist/*; do
+            if [[ ! -f "$candidate" ]]; then
+              continue
+            fi
+
+            filename="$(basename "$candidate")"
+            staged_name="$filename"
+
+            if [[ "$filename" != *"-${{ matrix.architecture }}."* ]]; then
+              extension="${filename##*.}"
+              basename="${filename%.*}"
+
+              if [[ "$basename" == "$filename" ]]; then
+                staged_name="${filename}-${{ matrix.architecture }}"
+              else
+                staged_name="${basename}-${{ matrix.architecture }}.${extension}"
+              fi
+            fi
+
+            cp "$candidate" "nativephp/electron/release-assets/$staged_name"
+            staged_files=$((staged_files + 1))
+          done
+
+          if (( staged_files == 0 )); then
+            echo "No macOS release files were generated." >&2
+            exit 1
+          fi
 
       - name: Upload workflow artifact
         uses: actions/upload-artifact@v4
         with:
-          name: katra-macos-x64-${{ needs.context.outputs.version }}
-          path: ${{ github.workspace }}/nativephp/electron/dist
+          name: katra-macos-${{ matrix.architecture }}-${{ needs.context.outputs.version }}
+          path: ${{ github.workspace }}/nativephp/electron/release-assets
           if-no-files-found: error
 
       - name: Upload release assets
@@ -192,7 +237,7 @@ jobs:
           shopt -s nullglob
           release_files=()
 
-          for candidate in nativephp/electron/dist/*; do
+          for candidate in nativephp/electron/release-assets/*; do
             if [[ -f "$candidate" ]]; then
               release_files+=("$candidate")
             fi
@@ -210,8 +255,8 @@ jobs:
           {
             echo "## macOS Packaging"
             echo
-            echo "- Runner: \`macos-15-intel\`"
-            echo "- Architecture: \`x64\`"
+            echo "- Runner: \`${{ matrix.runner }}\`"
+            echo "- Architecture: \`${{ matrix.architecture }}\`"
             echo "- Release tag: \`${{ needs.context.outputs.tag }}\`"
             echo
             if [[ -n "${NATIVEPHP_APPLE_ID}" && -n "${NATIVEPHP_APPLE_ID_PASS}" && -n "${NATIVEPHP_APPLE_TEAM_ID}" ]]; then

--- a/docs/development/nativephp.md
+++ b/docs/development/nativephp.md
@@ -64,13 +64,14 @@ php artisan native:run --no-interaction
 
 ## Release Artifacts
 
-Tagged releases build macOS desktop artifacts in GitHub Actions and attach the generated top-level `nativephp/electron/dist` files to the GitHub Release.
+Tagged releases build macOS desktop artifacts in GitHub Actions, stage a release-safe copy of the generated files, and attach those staged assets to the GitHub Release.
 
 The current workflow intentionally keeps this first packaging path small:
 
 - target platform: macOS
 - current architecture targets: `x64` and `arm64`
-- workflow artifact: preserved in GitHub Actions
+- raw build output: generated under `nativephp/electron/dist`
+- workflow artifact: preserved from the staged `nativephp/electron/release-assets` directory
 - release assets: uploaded to the matching GitHub Release with architecture-explicit filenames
 - current GitHub-hosted runners: `macos-15-intel` for Intel builds and `macos-15` for Apple Silicon builds
 

--- a/docs/development/nativephp.md
+++ b/docs/development/nativephp.md
@@ -64,14 +64,15 @@ php artisan native:run --no-interaction
 
 ## Release Artifacts
 
-Tagged releases build a macOS desktop artifact in GitHub Actions and attach the generated top-level `nativephp/electron/dist` files to the GitHub Release.
+Tagged releases build macOS desktop artifacts in GitHub Actions and attach the generated top-level `nativephp/electron/dist` files to the GitHub Release.
 
 The current workflow intentionally keeps this first packaging path small:
 
 - target platform: macOS
-- current architecture target: `x64`
+- current architecture targets: `x64` and `arm64`
 - workflow artifact: preserved in GitHub Actions
-- release assets: uploaded to the matching GitHub Release
+- release assets: uploaded to the matching GitHub Release with architecture-explicit filenames
+- current GitHub-hosted runners: `macos-15-intel` for Intel builds and `macos-15` for Apple Silicon builds
 
 ### Signing And Notarization
 


### PR DESCRIPTION
## Summary

- build tagged macOS releases on both Intel and Apple Silicon GitHub-hosted runners
- preserve and upload architecture-specific release assets for each build without cross-arch filename collisions
- document the dual-architecture macOS release flow in the NativePHP development guide

## Related Issues

Closes #67

## Testing

- [x] Not run
- [ ] Tests added
- [ ] Tests updated
- [ ] Existing tests pass

Notes:

- validated `.github/workflows/tagged-release.yml` as YAML
- ran `git diff --check`
- smoke-tested the asset staging logic in a local shell to confirm generic files like `builder-debug.yml` are suffixed per architecture while files already named with `-x64` or `-arm64` stay intact
- confirmed `php artisan native:build --help` advertises `x64` and `arm64` as supported architecture arguments in this app's installed NativePHP version

## Docs Impact

- [ ] None
- [ ] README updated
- [x] Docs updated
- [ ] Follow-up docs issue opened

Notes:

- updated the NativePHP development doc to describe the dual-architecture macOS release path and runner labels
