### PR TITLE
docs: refresh the Katra install and preview story

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The long-term direction is a graph-native system where conversations, tasks, dec
 
 - Laravel 13
 - NativePHP
-- SurrealDB v3, embedded-first
+- SurrealDB v3 with a desktop-embedded and server-remote runtime strategy
 - Laravel AI
 - Laravel MCP
 - Laravel Fortify
@@ -36,7 +36,26 @@ The long-term direction is a graph-native system where conversations, tasks, dec
 
 ## Current Status
 
-Katra v2 is an active rewrite. The repository is being reset and rebuilt in small, reviewable pull requests. The proof of concept is preserved at [`v1.0.0`](https://github.com/devoption/katra/tree/v1.0.0) for historical reference and is not being actively developed.
+Katra v2 is an active rewrite. The repository is being rebuilt in small, reviewable pull requests, and preview macOS desktop artifacts are now attached to GitHub Releases as the shell evolves. The proof of concept is preserved at [`v1.0.0`](https://github.com/devoption/katra/tree/v1.0.0) for historical reference and is not being actively developed.
+
+## Try Katra
+
+There are two practical ways to try Katra today.
+
+### Download A Desktop Preview
+
+- Browse the [GitHub Releases](https://github.com/devoption/katra/releases) page and download the latest macOS desktop asset for your machine.
+- Choose the architecture-specific asset that matches your Mac when it is available: `x64` for Intel, `arm64` for Apple Silicon.
+- Current desktop builds are preview-quality and the app is not yet signed or notarized, so macOS may require `Open Anyway` or a control-click `Open` flow the first time you launch it.
+
+### Run From Source
+
+```bash
+composer setup
+composer native:dev
+```
+
+That path installs dependencies, prepares the Laravel app, bootstraps NativePHP, and starts the local desktop development loop.
 
 ## Planning Docs
 
@@ -52,7 +71,7 @@ Contributions are welcome as the rewrite takes shape. For now, the best place to
 Repository workflow, commit conventions, and release policy are documented in [CONTRIBUTING.md](CONTRIBUTING.md).
 
 Optional local AI tooling setup is documented in [Laravel Boost Setup](docs/development/laravel-boost.md).
-Native desktop bootstrap and local shell setup are documented in [NativePHP Desktop Setup](docs/development/nativephp.md).
+Native desktop bootstrap, release artifacts, and local shell setup are documented in [NativePHP Desktop Setup](docs/development/nativephp.md).
 
 ## License
 

--- a/docs/development/nativephp.md
+++ b/docs/development/nativephp.md
@@ -62,6 +62,14 @@ If you want to run the NativePHP shell directly and manage frontend tooling sepa
 php artisan native:run --no-interaction
 ```
 
+## Trying A Release Build
+
+If you want to try Katra without cloning the repository, use the desktop assets attached to the [GitHub Releases](https://github.com/devoption/katra/releases) page.
+
+- choose the asset that matches your Mac architecture when it is available: `x64` for Intel or `arm64` for Apple Silicon
+- expect preview-quality behavior while the desktop shell and local runtime story are still being built out
+- expect Gatekeeper prompts until macOS signing and notarization are in place
+
 ## Release Artifacts
 
 Tagged releases build macOS desktop artifacts in GitHub Actions, stage a release-safe copy of the generated files, and attach those staged assets to the GitHub Release.

--- a/docs/v2-overview.md
+++ b/docs/v2-overview.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Katra v2 is an in-progress rewrite of the original proof of concept. The rewrite is happening in the open through small pull requests and linked GitHub issues.
+Katra v2 is an in-progress rewrite of the original proof of concept. The rewrite is happening in the open through small pull requests and linked GitHub issues, and preview macOS desktop artifacts now ship through GitHub Releases as the shell evolves.
 
 ## Product Direction
 


### PR DESCRIPTION
## Summary

- review the high-signal repo docs for drift against the current desktop and release state
- update the README so it explains how to download a desktop preview or run Katra from source
- refresh the NativePHP and v2 overview docs so they reflect the current release artifact story

## Related Issues

Closes #80

## Testing

- [x] Not run
- [ ] Tests added
- [ ] Tests updated
- [ ] Existing tests pass

Notes:

- ran `git diff --check`
- verified the current public release state with `gh release list` and `gh release view v2.1.2 --json assets,...` before tightening the install language

## Docs Impact

- [ ] None
- [ ] README updated
- [x] Docs updated
- [ ] Follow-up docs issue opened

Notes:

- the README now includes a practical desktop preview path and local source setup path
- the NativePHP doc now includes a release-build usage section and Gatekeeper caveat
