### PR TITLE
feat: bundle the Surreal runtime into desktop releases

### DIFF
--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -136,8 +136,10 @@ jobs:
         include:
           - architecture: x64
             runner: macos-15-intel
+            surreal_asset_architecture: amd64
           - architecture: arm64
             runner: macos-15
+            surreal_asset_architecture: arm64
     runs-on: ${{ matrix.runner }}
     env:
       GH_TOKEN: ${{ github.token }}
@@ -147,6 +149,7 @@ jobs:
       NATIVEPHP_APPLE_ID: ${{ secrets.NATIVEPHP_APPLE_ID }}
       NATIVEPHP_APPLE_ID_PASS: ${{ secrets.NATIVEPHP_APPLE_ID_PASS }}
       NATIVEPHP_APPLE_TEAM_ID: ${{ secrets.NATIVEPHP_APPLE_TEAM_ID }}
+      SURREAL_VERSION: v3.0.4
 
     steps:
       - name: Checkout
@@ -180,6 +183,24 @@ jobs:
 
       - name: Install NativePHP resources
         run: php artisan native:install --force --no-interaction
+
+      - name: Bundle Surreal runtime
+        run: |
+          set -euo pipefail
+
+          runtime_dir="extras/surreal/bin"
+          archive="surreal-${SURREAL_VERSION}.darwin-${{ matrix.surreal_asset_architecture }}.tgz"
+
+          rm -rf extras/surreal
+          mkdir -p "$runtime_dir" build/surreal-runtime
+
+          gh release download "$SURREAL_VERSION" \
+            --repo surrealdb/surrealdb \
+            --pattern "$archive" \
+            --dir build/surreal-runtime
+
+          tar -xzf "build/surreal-runtime/$archive" -C "$runtime_dir"
+          chmod +x "$runtime_dir/surreal"
 
       - name: Build macOS desktop artifact
         run: php artisan native:build mac ${{ matrix.architecture }} --no-interaction
@@ -258,6 +279,7 @@ jobs:
             echo "- Runner: \`${{ matrix.runner }}\`"
             echo "- Architecture: \`${{ matrix.architecture }}\`"
             echo "- Release tag: \`${{ needs.context.outputs.tag }}\`"
+            echo "- Bundled Surreal runtime: \`${SURREAL_VERSION}\` (\`${{ matrix.surreal_asset_architecture }}\` asset)"
             echo
             if [[ -n "${NATIVEPHP_APPLE_ID}" && -n "${NATIVEPHP_APPLE_ID_PASS}" && -n "${NATIVEPHP_APPLE_TEAM_ID}" ]]; then
               echo "- Apple notarization credentials were provided to the build."

--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -190,6 +190,7 @@ jobs:
 
           runtime_dir="extras/surreal/bin"
           archive="surreal-${SURREAL_VERSION}.darwin-${{ matrix.surreal_asset_architecture }}.tgz"
+          archive_path="build/surreal-runtime/$archive"
 
           rm -rf extras/surreal
           mkdir -p "$runtime_dir" build/surreal-runtime
@@ -199,7 +200,21 @@ jobs:
             --pattern "$archive" \
             --dir build/surreal-runtime
 
-          tar -xzf "build/surreal-runtime/$archive" -C "$runtime_dir"
+          expected_digest="$(gh api repos/surrealdb/surrealdb/releases/tags/${SURREAL_VERSION} --jq ".assets[] | select(.name == \"${archive}\") | .digest")"
+
+          if [[ -z "$expected_digest" || "$expected_digest" == "null" ]]; then
+            echo "Unable to resolve a published digest for ${archive}." >&2
+            exit 1
+          fi
+
+          actual_digest="sha256:$(shasum -a 256 "$archive_path" | awk '{print $1}')"
+
+          if [[ "$actual_digest" != "$expected_digest" ]]; then
+            echo "Digest mismatch for ${archive}: expected ${expected_digest}, got ${actual_digest}." >&2
+            exit 1
+          fi
+
+          tar -xzf "$archive_path" -C "$runtime_dir"
           chmod +x "$runtime_dir/surreal"
 
       - name: Build macOS desktop artifact

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ There are two practical ways to try Katra today.
 
 - Browse the [GitHub Releases](https://github.com/devoption/katra/releases) page and download the latest macOS desktop asset for your machine.
 - Choose the architecture-specific asset that matches your Mac when it is available: `x64` for Intel, `arm64` for Apple Silicon.
+- Desktop preview builds now bundle the local Surreal runtime instead of expecting a separate machine-local `surreal` CLI install.
 - Current desktop builds are preview-quality and the app is not yet signed or notarized, so macOS may require `Open Anyway` or a control-click `Open` flow the first time you launch it.
 
 ### Run From Source

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -21,7 +21,11 @@ class HomeController extends Controller
         try {
             $workspace = Workspace::desktopPreview();
             $surrealStatus = 'connected';
-            $runtimeLabel = $client->usesBundledBinary() ? 'bundled Surreal runtime' : 'local Surreal runtime';
+            $runtimeLabel = match (true) {
+                ! $connection->usesLocalRuntime() => 'remote Surreal runtime',
+                $client->usesBundledBinary() => 'bundled Surreal runtime',
+                default => 'local Surreal runtime',
+            };
             $surrealMessage = sprintf('The preview workspace is persisted through the %s at %s.', $runtimeLabel, $connection->endpoint);
         } catch (Throwable $exception) {
             if ($exception instanceof RuntimeException) {

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Models\Workspace;
+use App\Services\Surreal\SurrealCliClient;
 use App\Services\Surreal\SurrealConnection;
 use Illuminate\Support\Str;
 use Illuminate\View\View;
@@ -11,7 +12,7 @@ use Throwable;
 
 class HomeController extends Controller
 {
-    public function __invoke(SurrealConnection $connection): View
+    public function __invoke(SurrealConnection $connection, SurrealCliClient $client): View
     {
         $workspace = null;
         $surrealStatus = 'degraded';
@@ -20,7 +21,8 @@ class HomeController extends Controller
         try {
             $workspace = Workspace::desktopPreview();
             $surrealStatus = 'connected';
-            $surrealMessage = sprintf('The preview workspace is persisted through the Surreal foundation at %s.', $connection->endpoint);
+            $runtimeLabel = $client->usesBundledBinary() ? 'bundled Surreal runtime' : 'local Surreal runtime';
+            $surrealMessage = sprintf('The preview workspace is persisted through the %s at %s.', $runtimeLabel, $connection->endpoint);
         } catch (Throwable $exception) {
             if ($exception instanceof RuntimeException) {
                 $surrealMessage = Str::limit($exception->getMessage(), 220);

--- a/app/Services/Surreal/SurrealCliClient.php
+++ b/app/Services/Surreal/SurrealCliClient.php
@@ -11,6 +11,8 @@ class SurrealCliClient
 {
     public function __construct(
         private readonly ?string $configuredBinary = null,
+        private readonly ?string $extrasPath = null,
+        private readonly ?string $bundledBinaryRelativePath = null,
     ) {}
 
     public function isAvailable(): bool
@@ -167,13 +169,31 @@ class SurrealCliClient
 
     public function binary(): ?string
     {
-        $binary = $this->configuredBinary ?: (string) config('surreal.binary', 'surreal');
+        foreach ($this->binaryCandidates() as $candidate) {
+            if (is_file($candidate) && is_executable($candidate)) {
+                return $candidate;
+            }
 
-        if (is_file($binary) && is_executable($binary)) {
-            return $binary;
+            $resolvedBinary = (new ExecutableFinder)->find($candidate);
+
+            if ($resolvedBinary !== null) {
+                return $resolvedBinary;
+            }
         }
 
-        return (new ExecutableFinder)->find($binary);
+        return null;
+    }
+
+    public function usesBundledBinary(): bool
+    {
+        $bundledBinary = $this->bundledBinary();
+        $resolvedBinary = $this->binary();
+
+        if ($bundledBinary === null || $resolvedBinary === null) {
+            return false;
+        }
+
+        return realpath($bundledBinary) === realpath($resolvedBinary);
     }
 
     /**
@@ -215,9 +235,70 @@ class SurrealCliClient
         $binary = $this->binary();
 
         if ($binary === null) {
-            throw new RuntimeException('Unable to find the `surreal` CLI. Install it or set SURREAL_BINARY to the executable path.');
+            throw new RuntimeException('Unable to find the `surreal` CLI. '.implode(' ', $this->missingBinaryGuidance()));
         }
 
         return $binary;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function binaryCandidates(): array
+    {
+        $configuredBinary = $this->configuredBinary ?: (string) config('surreal.binary', 'surreal');
+        $defaultBinary = (string) config('surreal.binary', 'surreal');
+        $bundledBinary = $this->bundledBinary();
+
+        return array_values(array_unique(array_filter([
+            $configuredBinary !== $defaultBinary ? $configuredBinary : null,
+            $bundledBinary,
+            $configuredBinary,
+        ])));
+    }
+
+    private function bundledBinary(): ?string
+    {
+        $extrasPath = $this->extrasPath;
+
+        if ($extrasPath === null || $extrasPath === '') {
+            $configuredExtrasPath = config('surreal.extras_path');
+
+            if (is_string($configuredExtrasPath) && $configuredExtrasPath !== '') {
+                $extrasPath = $configuredExtrasPath;
+            }
+        }
+
+        if ($extrasPath === null || $extrasPath === '') {
+            return null;
+        }
+
+        $bundledBinaryRelativePath = $this->bundledBinaryRelativePath;
+
+        if ($bundledBinaryRelativePath === null || $bundledBinaryRelativePath === '') {
+            $configuredBundledPath = config('surreal.bundled_binary_relative_path', 'surreal/bin/surreal');
+            $bundledBinaryRelativePath = is_string($configuredBundledPath) ? $configuredBundledPath : 'surreal/bin/surreal';
+        }
+
+        return rtrim($extrasPath, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.ltrim($bundledBinaryRelativePath, DIRECTORY_SEPARATOR);
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function missingBinaryGuidance(): array
+    {
+        $guidance = [];
+        $bundledBinary = $this->bundledBinary();
+
+        if ($bundledBinary !== null) {
+            $guidance[] = sprintf('Checked bundled NativePHP extras path [%s].', $bundledBinary);
+        }
+
+        $configuredBinary = $this->configuredBinary ?: (string) config('surreal.binary', 'surreal');
+        $guidance[] = sprintf('Checked the current process PATH for [%s].', $configuredBinary);
+        $guidance[] = 'Install the CLI manually for local source development or set SURREAL_BINARY to a custom executable path.';
+
+        return $guidance;
     }
 }

--- a/app/Services/Surreal/SurrealCliClient.php
+++ b/app/Services/Surreal/SurrealCliClient.php
@@ -247,7 +247,7 @@ class SurrealCliClient
     private function binaryCandidates(): array
     {
         $configuredBinary = $this->configuredBinary ?: (string) config('surreal.binary', 'surreal');
-        $defaultBinary = (string) config('surreal.binary', 'surreal');
+        $defaultBinary = 'surreal';
         $bundledBinary = $this->bundledBinary();
 
         return array_values(array_unique(array_filter([

--- a/app/Services/Surreal/SurrealCliClient.php
+++ b/app/Services/Surreal/SurrealCliClient.php
@@ -296,9 +296,18 @@ class SurrealCliClient
         }
 
         $configuredBinary = $this->configuredBinary ?: (string) config('surreal.binary', 'surreal');
-        $guidance[] = sprintf('Checked the current process PATH for [%s].', $configuredBinary);
+        $guidance[] = $this->looksLikeBinaryPath($configuredBinary)
+            ? sprintf('Checked configured Surreal binary path [%s].', $configuredBinary)
+            : sprintf('Checked the current process PATH for [%s].', $configuredBinary);
         $guidance[] = 'Install the CLI manually for local source development or set SURREAL_BINARY to a custom executable path.';
 
         return $guidance;
+    }
+
+    private function looksLikeBinaryPath(string $binary): bool
+    {
+        return str_contains($binary, '/')
+            || str_contains($binary, '\\')
+            || str_starts_with($binary, '.');
     }
 }

--- a/config/surreal.php
+++ b/config/surreal.php
@@ -21,6 +21,10 @@ return [
 
     'binary' => env('SURREAL_BINARY', 'surreal'),
 
+    'extras_path' => env('NATIVEPHP_EXTRAS_PATH'),
+
+    'bundled_binary_relative_path' => env('SURREAL_BUNDLED_BINARY_RELATIVE_PATH', 'surreal/bin/surreal'),
+
     'host' => env('SURREAL_HOST', '127.0.0.1'),
 
     'port' => (int) env('SURREAL_PORT', 18001),

--- a/docs/architecture/surreal-integration-strategy.md
+++ b/docs/architecture/surreal-integration-strategy.md
@@ -143,7 +143,8 @@ That means:
 
 - local desktop development can auto-start a local Surreal runtime when the CLI is available
 - remote or server deployments can point Laravel at a separately managed SurrealDB endpoint
-- the desktop shell must degrade gracefully when the runtime is unavailable or not yet bundled into app distribution
+- downloadable macOS desktop releases can bundle the official SurrealDB CLI into NativePHP `extras` so the app can auto-start a local runtime without a separate user install
+- the desktop shell should still degrade gracefully in local source environments when no CLI is available
 
 ## Eloquent Strategy
 

--- a/docs/development/nativephp.md
+++ b/docs/development/nativephp.md
@@ -67,6 +67,7 @@ php artisan native:run --no-interaction
 If you want to try Katra without cloning the repository, use the desktop assets attached to the [GitHub Releases](https://github.com/devoption/katra/releases) page.
 
 - choose the asset that matches your Mac architecture when it is available: `x64` for Intel or `arm64` for Apple Silicon
+- release builds now bundle the Surreal runtime through NativePHP `extras`, so the desktop shell does not require a separate machine-local `surreal` CLI install
 - expect preview-quality behavior while the desktop shell and local runtime story are still being built out
 - expect Gatekeeper prompts until macOS signing and notarization are in place
 
@@ -80,6 +81,7 @@ The current workflow intentionally keeps this first packaging path small:
 - current architecture targets: `x64` and `arm64`
 - raw build output: generated under `nativephp/electron/dist`
 - workflow artifact: preserved from the staged `nativephp/electron/release-assets` directory
+- bundled local data runtime: the official SurrealDB macOS CLI is downloaded during release builds and packaged under NativePHP `extras`
 - release assets: uploaded to the matching GitHub Release with architecture-explicit filenames
 - current GitHub-hosted runners: `macos-15-intel` for Intel builds and `macos-15` for Apple Silicon builds
 

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -75,9 +75,9 @@
 
                             <article class="rounded-[28px] border border-emerald-200/12 bg-emerald-300/8 p-5">
                                 <p class="font-mono text-[11px] uppercase tracking-[0.28em] text-emerald-100/70">Release</p>
-                                <h2 class="mt-4 text-2xl font-semibold text-white">Downloadable preview</h2>
+                                <h2 class="mt-4 text-2xl font-semibold text-white">Bundled preview</h2>
                                 <p class="mt-3 text-sm leading-7 text-slate-200/78">
-                                    The release flow is in place, and the next release-worthy feature merge should produce the first downloadable macOS preview artifact for the Katra rewrite line.
+                                    Downloadable macOS previews can now carry the local Surreal runtime instead of depending on a separately installed machine-local CLI.
                                 </p>
                             </article>
                         </div>
@@ -138,7 +138,7 @@
                                 <ul class="mt-4 space-y-3 text-sm leading-6 text-slate-200/78">
                                     <li>Graph repositories and Surreal-backed model flows beyond the preview workspace</li>
                                     <li>Fortify auth and conversation scaffolding inside the desktop shell</li>
-                                    <li>Bundled Surreal runtime decisions for downloadable desktop builds</li>
+                                    <li>Signed desktop builds, auto-updates, and release polish</li>
                                 </ul>
                             </div>
 

--- a/tests/Feature/DesktopShellTest.php
+++ b/tests/Feature/DesktopShellTest.php
@@ -9,5 +9,6 @@ test('the desktop shell exposes the katra bootstrap screen', function () {
         ->assertSee('composer native:dev')
         ->assertSee('Katra is taking shape as a graph-native workspace')
         ->assertSee('Surreal Foundation')
-        ->assertSee('Downloadable preview');
+        ->assertSee('Bundled preview')
+        ->assertSee('local Surreal runtime');
 });

--- a/tests/Feature/SurrealCliClientTest.php
+++ b/tests/Feature/SurrealCliClientTest.php
@@ -43,3 +43,21 @@ test('it reports the bundled lookup path when no surreal binary is available', f
         File::deleteDirectory($extrasPath);
     }
 });
+
+test('it reports the configured binary path when the surreal binary is missing from an explicit path', function () {
+    $extrasPath = storage_path('framework/testing/nativephp-extras-'.Str::uuid());
+    $missingBinary = $extrasPath.'/custom/surreal';
+
+    try {
+        $client = new SurrealCliClient(
+            configuredBinary: $missingBinary,
+            extrasPath: null,
+            bundledBinaryRelativePath: null,
+        );
+
+        expect(fn () => $client->isReady('ws://127.0.0.1:18001'))
+            ->toThrow(RuntimeException::class, sprintf('Checked configured Surreal binary path [%s].', $missingBinary));
+    } finally {
+        File::deleteDirectory($extrasPath);
+    }
+});

--- a/tests/Feature/SurrealCliClientTest.php
+++ b/tests/Feature/SurrealCliClientTest.php
@@ -61,3 +61,33 @@ test('it reports the configured binary path when the surreal binary is missing f
         File::deleteDirectory($extrasPath);
     }
 });
+
+test('it honors an explicitly configured surreal binary before the bundled binary', function () {
+    $workspaceRoot = storage_path('framework/testing/nativephp-extras-'.Str::uuid());
+    $configuredBinary = $workspaceRoot.'/custom/surreal';
+    $bundledBinary = $workspaceRoot.'/extras/surreal/bin/surreal';
+
+    File::ensureDirectoryExists(dirname($configuredBinary));
+    File::put($configuredBinary, "#!/bin/sh\nexit 0\n");
+    chmod($configuredBinary, 0755);
+
+    File::ensureDirectoryExists(dirname($bundledBinary));
+    File::put($bundledBinary, "#!/bin/sh\nexit 0\n");
+    chmod($bundledBinary, 0755);
+
+    try {
+        config()->set('surreal.binary', $configuredBinary);
+
+        $client = new SurrealCliClient(
+            configuredBinary: null,
+            extrasPath: $workspaceRoot.'/extras',
+            bundledBinaryRelativePath: 'surreal/bin/surreal',
+        );
+
+        expect($client->binary())->toBe($configuredBinary)
+            ->and($client->usesBundledBinary())->toBeFalse();
+    } finally {
+        File::deleteDirectory($workspaceRoot);
+        config()->set('surreal.binary', 'surreal');
+    }
+});

--- a/tests/Feature/SurrealCliClientTest.php
+++ b/tests/Feature/SurrealCliClientTest.php
@@ -1,0 +1,45 @@
+<?php
+
+use App\Services\Surreal\SurrealCliClient;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+
+test('it prefers a bundled surreal binary from the nativephp extras path', function () {
+    $extrasPath = storage_path('framework/testing/nativephp-extras-'.Str::uuid());
+    $bundledBinary = $extrasPath.'/surreal/bin/surreal';
+
+    File::ensureDirectoryExists(dirname($bundledBinary));
+    File::put($bundledBinary, "#!/bin/sh\nexit 0\n");
+    chmod($bundledBinary, 0755);
+
+    try {
+        $client = new SurrealCliClient(
+            configuredBinary: 'surreal',
+            extrasPath: $extrasPath,
+            bundledBinaryRelativePath: 'surreal/bin/surreal',
+        );
+
+        expect($client->binary())->toBe($bundledBinary)
+            ->and($client->usesBundledBinary())->toBeTrue();
+    } finally {
+        File::deleteDirectory($extrasPath);
+    }
+});
+
+test('it reports the bundled lookup path when no surreal binary is available', function () {
+    $extrasPath = storage_path('framework/testing/nativephp-extras-'.Str::uuid());
+    $missingBinary = 'surreal-missing-binary-for-test';
+
+    try {
+        $client = new SurrealCliClient(
+            configuredBinary: $missingBinary,
+            extrasPath: $extrasPath,
+            bundledBinaryRelativePath: 'surreal/bin/surreal',
+        );
+
+        expect(fn () => $client->isReady('ws://127.0.0.1:18001'))
+            ->toThrow(RuntimeException::class, sprintf('Checked bundled NativePHP extras path [%s].', $extrasPath.'/surreal/bin/surreal'));
+    } finally {
+        File::deleteDirectory($extrasPath);
+    }
+});


### PR DESCRIPTION
## Summary

- bundle the official SurrealDB macOS CLI into NativePHP desktop release builds so downloadable previews do not depend on a machine-local `surreal` install
- teach the Surreal runtime bridge to prefer the bundled binary and report clearer lookup diagnostics when no runtime is available
- update the desktop shell and docs to reflect that downloadable previews now carry the local runtime

## Related Issues

Closes #66

## Testing

- [ ] Not run
- [x] Tests added
- [x] Tests updated
- [x] Existing tests pass

Notes:

- ran `vendor/bin/pint --dirty --format agent`
- ran `php artisan test --compact tests/Feature/SurrealCliClientTest.php tests/Feature/DesktopShellTest.php`
- ran `php artisan test --compact`
- ran `npm run build`
- validated `.github/workflows/tagged-release.yml` as YAML
- ran `git diff --check`
- verified the bundled SurrealDB archive layout from the official `surrealdb/surrealdb` release assets before wiring the workflow download

## Docs Impact

- [ ] None
- [x] README updated
- [x] Docs updated
- [ ] Follow-up docs issue opened

Notes:

- the README and NativePHP docs now explain that release builds bundle the local Surreal runtime
- the Surreal integration strategy doc now records the NativePHP `extras` bundling approach for desktop releases
