### PR TITLE
fix: make arm64 desktop previews launch

### DIFF
--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -146,10 +146,8 @@ jobs:
       GITHUB_TOKEN: ${{ github.token }}
       NATIVEPHP_APP_VERSION: ${{ needs.context.outputs.version }}
       NATIVEPHP_UPDATER_ENABLED: false
-      NATIVEPHP_APPLE_ID: ${{ secrets.NATIVEPHP_APPLE_ID }}
-      NATIVEPHP_APPLE_ID_PASS: ${{ secrets.NATIVEPHP_APPLE_ID_PASS }}
-      NATIVEPHP_APPLE_TEAM_ID: ${{ secrets.NATIVEPHP_APPLE_TEAM_ID }}
       SURREAL_VERSION: v3.0.4
+      CSC_IDENTITY_AUTO_DISCOVERY: 'false'
 
     steps:
       - name: Checkout
@@ -216,6 +214,48 @@ jobs:
 
           tar -xzf "$archive_path" -C "$runtime_dir"
           chmod +x "$runtime_dir/surreal"
+
+      - name: Force consistent ad-hoc macOS signing
+        run: |
+          node <<'NODE'
+          const { readFileSync, writeFileSync } = require('node:fs');
+
+          const path = 'vendor/nativephp/desktop/resources/electron/electron-builder.mjs';
+          const current = readFileSync(path, 'utf8');
+          const normalized = current.replace(/\r\n/g, '\n');
+          const pattern = /^(\s*mac:\s*\{\n)([\s\S]*?)(^\s*\},\n)/m;
+          const match = normalized.match(pattern);
+
+          if (! match) {
+            throw new Error('Unable to locate the NativePHP mac builder block.');
+          }
+
+          const macBlock = match[2];
+
+          if (! macBlock.includes("entitlementsInherit: 'build/entitlements.mac.plist'")) {
+            throw new Error('NativePHP mac builder block is missing entitlementsInherit.');
+          }
+
+          const adHocSettings = [
+            "        identity: '-'",
+            '        hardenedRuntime: false',
+            '        notarize: false',
+            '        gatekeeperAssess: false',
+          ];
+
+          const updatedMacBlock = macBlock.includes("identity: '-'")
+            ? macBlock
+            : macBlock.replace(
+                /(^\s*entitlementsInherit:\s*'build\/entitlements\.mac\.plist',\n)/m,
+                `$1${adHocSettings.join('\n')}\n`,
+              );
+
+          if (updatedMacBlock === macBlock) {
+            throw new Error('Unable to apply preview macOS signing overrides.');
+          }
+
+          writeFileSync(path, normalized.replace(pattern, `$1${updatedMacBlock}$3`));
+          NODE
 
       - name: Build macOS desktop artifact
         run: php artisan native:build mac ${{ matrix.architecture }} --no-interaction
@@ -296,9 +336,6 @@ jobs:
             echo "- Release tag: \`${{ needs.context.outputs.tag }}\`"
             echo "- Bundled Surreal runtime: \`${SURREAL_VERSION}\` (\`${{ matrix.surreal_asset_architecture }}\` asset)"
             echo
-            if [[ -n "${NATIVEPHP_APPLE_ID}" && -n "${NATIVEPHP_APPLE_ID_PASS}" && -n "${NATIVEPHP_APPLE_TEAM_ID}" ]]; then
-              echo "- Apple notarization credentials were provided to the build."
-            else
-              echo "- Apple notarization credentials were not provided. The workflow still builds and uploads macOS artifacts, but notarization/signing follow-up remains manual."
-            fi
+            echo "- Preview builds are packaged with an explicit ad-hoc macOS signature for launch consistency."
+            echo "- Developer ID signing and notarization remain tracked separately before trusted distribution."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ There are two practical ways to try Katra today.
 - Browse the [GitHub Releases](https://github.com/devoption/katra/releases) page and download the latest macOS desktop asset for your machine.
 - Choose the architecture-specific asset that matches your Mac when it is available: `x64` for Intel, `arm64` for Apple Silicon.
 - Desktop preview builds now bundle the local Surreal runtime instead of expecting a separate machine-local `surreal` CLI install.
-- Current desktop builds are preview-quality and the app is not yet signed or notarized, so macOS may require `Open Anyway` or a control-click `Open` flow the first time you launch it.
+- Current desktop builds are preview-quality and use ad-hoc macOS signing, so macOS may require `Open Anyway` or a control-click `Open` flow the first time you launch it.
 
 ### Run From Source
 

--- a/docs/development/nativephp.md
+++ b/docs/development/nativephp.md
@@ -69,7 +69,7 @@ If you want to try Katra without cloning the repository, use the desktop assets 
 - choose the asset that matches your Mac architecture when it is available: `x64` for Intel or `arm64` for Apple Silicon
 - release builds now bundle the Surreal runtime through NativePHP `extras`, so the desktop shell does not require a separate machine-local `surreal` CLI install
 - expect preview-quality behavior while the desktop shell and local runtime story are still being built out
-- expect Gatekeeper prompts until macOS signing and notarization are in place
+- expect Gatekeeper prompts until Developer ID signing and notarization are in place
 
 ## Release Artifacts
 
@@ -87,13 +87,9 @@ The current workflow intentionally keeps this first packaging path small:
 
 ### Signing And Notarization
 
-If the repository provides the following secrets, the macOS build can attempt notarization during packaging:
+Preview release builds currently force a consistent ad-hoc macOS signature during packaging and disable hardened runtime/notarization in that path so the generated Intel and Apple Silicon apps launch reliably after download.
 
-- `NATIVEPHP_APPLE_ID`
-- `NATIVEPHP_APPLE_ID_PASS`
-- `NATIVEPHP_APPLE_TEAM_ID`
-
-If those secrets are not configured, the workflow still builds and uploads artifacts, but signing and notarization remain a manual follow-up step.
+That keeps the release artifacts usable for early testing, but they are still not trusted macOS distributions. Gatekeeper prompts remain expected until dedicated Developer ID signing, notarization, and stapling land through the tracked distribution work.
 
 ## Current Bootstrap Behavior
 


### PR DESCRIPTION
## Summary
- force preview macOS release builds onto a consistent ad-hoc signing path
- disable hardened runtime and notarization in that preview packaging path so Electron can load its framework on Apple Silicon
- update the install docs to match the current ad-hoc preview distribution model

## Testing
- ruby -e "require 'psych'; Psych.load_file('.github/workflows/tagged-release.yml'); puts 'parsed .github/workflows/tagged-release.yml'"
- git diff --check
- local arm64 NativePHP build with the preview signing override applied
- local launch smoke of nativephp/electron/dist/mac-arm64/Laravel.app/Contents/MacOS/Laravel (Electron API server and PHP server started successfully)

Closes #83