### PR TITLE
fix: repair preview signing patch generation

### DIFF
--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -237,10 +237,10 @@ jobs:
           }
 
           const adHocSettings = [
-            "        identity: '-'",
-            '        hardenedRuntime: false',
-            '        notarize: false',
-            '        gatekeeperAssess: false',
+            "        identity: '-',",
+            '        hardenedRuntime: false,',
+            '        notarize: false,',
+            '        gatekeeperAssess: false,',
           ];
 
           const updatedMacBlock = macBlock.includes("identity: '-'")
@@ -256,6 +256,9 @@ jobs:
 
           writeFileSync(path, normalized.replace(pattern, `$1${updatedMacBlock}$3`));
           NODE
+
+      - name: Validate patched Electron builder config
+        run: node --check vendor/nativephp/desktop/resources/electron/electron-builder.mjs
 
       - name: Build macOS desktop artifact
         run: php artisan native:build mac ${{ matrix.architecture }} --no-interaction


### PR DESCRIPTION
## Summary
- fix the macOS preview signing patch so the injected Electron builder properties include trailing commas
- add a syntax-check step after patching `electron-builder.mjs` so malformed config fails before packaging
- keep the existing bundled Surreal runtime behavior intact

## Testing
- ruby -e "require 'psych'; Psych.load_file('.github/workflows/tagged-release.yml'); puts 'parsed .github/workflows/tagged-release.yml'"
- git diff --check
- simulated the CI patch against the current NativePHP vendor `electron-builder.mjs` template and ran `node --check` on the patched file

Closes #85