### PR TITLE
feat: surface surreal runtime health in the desktop shell

### DIFF
--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Models\Workspace;
 use App\Services\Surreal\SurrealCliClient;
 use App\Services\Surreal\SurrealConnection;
+use App\Services\Surreal\SurrealRuntimeManager;
 use Illuminate\Support\Str;
 use Illuminate\View\View;
 use RuntimeException;
@@ -12,24 +13,51 @@ use Throwable;
 
 class HomeController extends Controller
 {
-    public function __invoke(SurrealConnection $connection, SurrealCliClient $client): View
+    public function __invoke(SurrealConnection $connection, SurrealCliClient $client, SurrealRuntimeManager $runtimeManager): View
     {
         $workspace = null;
         $surrealStatus = 'degraded';
         $surrealMessage = 'The Surreal-backed model layer is wired in, but the runtime is not available yet on this machine.';
+        $runtimeReady = false;
+        $runtimeLabel = $this->runtimeLabel($connection, $client);
+        $surrealDetails = [
+            ['label' => 'Runtime', 'value' => 'Unavailable'],
+            ['label' => 'Binary', 'value' => $this->binaryLabel($connection, $client)],
+            ['label' => 'Endpoint', 'value' => $connection->endpoint],
+        ];
 
         try {
+            $runtimeReady = $runtimeManager->ensureReady();
+            $runningProcessId = $runtimeManager->runningProcessId();
+
+            $surrealDetails[0]['value'] = $runtimeReady ? 'Running' : 'Unavailable';
+
+            if ($runningProcessId !== null) {
+                $surrealDetails[] = ['label' => 'Process', 'value' => sprintf('PID %d', $runningProcessId)];
+            }
+
+            if (! $runtimeReady) {
+                $surrealMessage = $connection->usesLocalRuntime()
+                    ? sprintf('The %s is configured for %s, but it is not responding yet.', $runtimeLabel, $connection->endpoint)
+                    : sprintf('The remote Surreal runtime is not responding at %s.', $connection->endpoint);
+
+                return view('welcome', [
+                    'workspace' => $workspace,
+                    'surrealStatus' => $surrealStatus,
+                    'surrealMessage' => $surrealMessage,
+                    'surrealDetails' => $surrealDetails,
+                ]);
+            }
+
             $workspace = Workspace::desktopPreview();
             $surrealStatus = 'connected';
-            $runtimeLabel = match (true) {
-                ! $connection->usesLocalRuntime() => 'remote Surreal runtime',
-                $client->usesBundledBinary() => 'bundled Surreal runtime',
-                default => 'local Surreal runtime',
-            };
             $surrealMessage = sprintf('The preview workspace is persisted through the %s at %s.', $runtimeLabel, $connection->endpoint);
         } catch (Throwable $exception) {
             if ($exception instanceof RuntimeException) {
-                $surrealMessage = Str::limit($exception->getMessage(), 220);
+                $surrealStatus = $runtimeReady ? 'runtime-ready' : 'degraded';
+                $surrealMessage = $runtimeReady
+                    ? sprintf('The %s is running at %s, but the preview workspace bootstrap failed: %s', $runtimeLabel, $connection->endpoint, Str::limit($exception->getMessage(), 160))
+                    : Str::limit($exception->getMessage(), 220);
             } else {
                 report($exception);
                 $surrealMessage = 'The Surreal-backed model layer hit an unexpected error while loading the preview workspace.';
@@ -40,6 +68,26 @@ class HomeController extends Controller
             'workspace' => $workspace,
             'surrealStatus' => $surrealStatus,
             'surrealMessage' => $surrealMessage,
+            'surrealDetails' => $surrealDetails,
         ]);
+    }
+
+    private function runtimeLabel(SurrealConnection $connection, SurrealCliClient $client): string
+    {
+        return match (true) {
+            ! $connection->usesLocalRuntime() => 'remote Surreal runtime',
+            $client->usesBundledBinary() => 'bundled Surreal runtime',
+            default => 'local Surreal runtime',
+        };
+    }
+
+    private function binaryLabel(SurrealConnection $connection, SurrealCliClient $client): string
+    {
+        return match (true) {
+            ! $connection->usesLocalRuntime() => 'Remote endpoint',
+            $client->usesBundledBinary() => 'Bundled preview binary',
+            $client->isAvailable() => 'Machine-local CLI',
+            default => 'Missing',
+        };
     }
 }

--- a/app/Services/Surreal/SurrealDocumentStore.php
+++ b/app/Services/Surreal/SurrealDocumentStore.php
@@ -26,7 +26,7 @@ class SurrealDocumentStore
      */
     public function find(string $table, string $id): ?array
     {
-        return $this->normalizeRecordSet($this->run(sprintf('SELECT * FROM %s;', $this->normalizeRecordId($table, $id)))[0] ?? [])[0] ?? null;
+        return $this->normalizeRecordSet($this->run(sprintf('SELECT * FROM %s;', $this->recordSelector($table, $id)))[0] ?? [])[0] ?? null;
     }
 
     /**
@@ -39,7 +39,7 @@ class SurrealDocumentStore
         $attributes['id'] = $id;
         $payload = Arr::except($attributes, ['id']);
 
-        return $this->normalizeRecordSet($this->run(sprintf('CREATE ONLY %s CONTENT %s;', $id, $this->encodeAttributes($payload)))[0] ?? [])[0]
+        return $this->normalizeRecordSet($this->run(sprintf('CREATE ONLY %s CONTENT %s;', $this->recordSelector($table, $id), $this->encodeAttributes($payload)))[0] ?? [])[0]
             ?? throw new RuntimeException(sprintf('Failed to create the SurrealDB record [%s].', $id));
     }
 
@@ -53,13 +53,13 @@ class SurrealDocumentStore
         $attributes['id'] = $recordId;
         $payload = Arr::except($attributes, ['id']);
 
-        return $this->normalizeRecordSet($this->run(sprintf('UPDATE %s CONTENT %s;', $recordId, $this->encodeAttributes($payload)))[0] ?? [])[0]
+        return $this->normalizeRecordSet($this->run(sprintf('UPDATE %s CONTENT %s;', $this->recordSelector($table, $recordId), $this->encodeAttributes($payload)))[0] ?? [])[0]
             ?? throw new RuntimeException(sprintf('Failed to update the SurrealDB record [%s].', $recordId));
     }
 
     public function delete(string $table, string $id): void
     {
-        $this->run(sprintf('DELETE %s;', $this->normalizeRecordId($table, $id)));
+        $this->run(sprintf('DELETE %s;', $this->recordSelector($table, $id)));
     }
 
     /**
@@ -104,6 +104,14 @@ class SurrealDocumentStore
         return sprintf('%s:%s', $normalizedTable, $id);
     }
 
+    private function recordSelector(string $table, string $id): string
+    {
+        $recordId = $this->normalizeRecordId($table, $id);
+        [$recordTable, $recordKey] = explode(':', $recordId, 2);
+
+        return sprintf('type::record(%s, %s)', $this->encodeString($recordTable), $this->encodeString($recordKey));
+    }
+
     private function normalizeTable(string $table): string
     {
         if (! preg_match('/^[A-Za-z0-9_]+$/', $table)) {
@@ -132,12 +140,12 @@ class SurrealDocumentStore
 
         if (is_array($firstValue) && $this->isAssociative($firstValue)) {
             /** @var array<int, array<string, mixed>> $values */
-            return $values;
+            return array_map(fn (array $record): array => $this->normalizeRecord($record), $values);
         }
 
         if (is_array($firstValue) && ! $this->isAssociative($firstValue)) {
             /** @var array<int, array<string, mixed>> $firstValue */
-            return $firstValue;
+            return array_map(fn (array $record): array => $this->normalizeRecord($record), $firstValue);
         }
 
         return [];
@@ -155,6 +163,30 @@ class SurrealDocumentStore
         }
 
         return $encoded;
+    }
+
+    private function encodeString(string $value): string
+    {
+        $encoded = json_encode($value, JSON_THROW_ON_ERROR);
+
+        if (! is_string($encoded)) {
+            throw new RuntimeException('Failed to encode the SurrealDB record identifier.');
+        }
+
+        return $encoded;
+    }
+
+    /**
+     * @param  array<string, mixed>  $record
+     * @return array<string, mixed>
+     */
+    private function normalizeRecord(array $record): array
+    {
+        if (isset($record['id']) && is_string($record['id'])) {
+            $record['id'] = preg_replace('/^([A-Za-z0-9_]+):`(.+)`$/', '$1:$2', $record['id']) ?? $record['id'];
+        }
+
+        return $record;
     }
 
     /**

--- a/app/Services/Surreal/SurrealRuntimeManager.php
+++ b/app/Services/Surreal/SurrealRuntimeManager.php
@@ -5,6 +5,7 @@ namespace App\Services\Surreal;
 use Illuminate\Support\Facades\File;
 use RuntimeException;
 use Symfony\Component\Process\Process;
+use Throwable;
 
 class SurrealRuntimeManager
 {
@@ -86,9 +87,17 @@ class SurrealRuntimeManager
             return @posix_kill($pid, 0);
         }
 
-        $process = new Process(['ps', '-p', (string) $pid]);
-        $process->run();
+        if (DIRECTORY_SEPARATOR === '\\') {
+            return false;
+        }
 
-        return $process->isSuccessful();
+        try {
+            $process = new Process(['ps', '-p', (string) $pid]);
+            $process->run();
+
+            return $process->isSuccessful();
+        } catch (Throwable) {
+            return false;
+        }
     }
 }

--- a/app/Services/Surreal/SurrealRuntimeManager.php
+++ b/app/Services/Surreal/SurrealRuntimeManager.php
@@ -4,6 +4,7 @@ namespace App\Services\Surreal;
 
 use Illuminate\Support\Facades\File;
 use RuntimeException;
+use Symfony\Component\Process\Process;
 
 class SurrealRuntimeManager
 {
@@ -62,5 +63,32 @@ class SurrealRuntimeManager
             flock($lockHandle, LOCK_UN);
             fclose($lockHandle);
         }
+    }
+
+    public function runningProcessId(): ?int
+    {
+        if (! $this->connection->usesLocalRuntime() || ! File::exists($this->connection->runtimePidPath)) {
+            return null;
+        }
+
+        $pid = (int) trim((string) File::get($this->connection->runtimePidPath));
+
+        if ($pid <= 0) {
+            return null;
+        }
+
+        return $this->processIsRunning($pid) ? $pid : null;
+    }
+
+    private function processIsRunning(int $pid): bool
+    {
+        if (function_exists('posix_kill')) {
+            return @posix_kill($pid, 0);
+        }
+
+        $process = new Process(['ps', '-p', (string) $pid]);
+        $process->run();
+
+        return $process->isSuccessful();
     }
 }

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -92,10 +92,25 @@
                                 <div class="grid gap-3 text-sm text-slate-200/80 sm:grid-cols-2">
                                     <div class="rounded-2xl border border-white/10 bg-white/5 px-4 py-3">
                                         <p class="font-mono text-[11px] uppercase tracking-[0.28em] text-slate-300/70">Surreal Foundation</p>
+                                        @php
+                                            $surrealStatusTone = match ($surrealStatus) {
+                                                'connected' => 'text-emerald-200',
+                                                'runtime-ready' => 'text-cyan-200',
+                                                default => 'text-amber-200',
+                                            };
+                                        @endphp
                                         <p class="mt-2">
-                                            <span class="font-mono uppercase tracking-[0.2em] {{ $surrealStatus === 'connected' ? 'text-emerald-200' : 'text-amber-200' }}">{{ $surrealStatus }}</span>
+                                            <span class="font-mono uppercase tracking-[0.2em] {{ $surrealStatusTone }}">{{ str_replace('-', ' ', $surrealStatus) }}</span>
                                         </p>
                                         <p class="mt-2">{{ $surrealMessage }}</p>
+                                        <dl class="mt-4 grid gap-3 text-xs text-slate-200/78 sm:grid-cols-2">
+                                            @foreach ($surrealDetails as $detail)
+                                                <div class="rounded-xl border border-white/8 bg-white/4 px-3 py-2">
+                                                    <dt class="font-mono uppercase tracking-[0.24em] text-slate-400/80">{{ $detail['label'] }}</dt>
+                                                    <dd class="mt-2 break-all font-mono text-[11px] text-sky-100/88">{{ $detail['value'] }}</dd>
+                                                </div>
+                                            @endforeach
+                                        </dl>
                                     </div>
                                     <div class="rounded-2xl border border-white/10 bg-white/5 px-4 py-3">
                                         <p class="font-mono text-[11px] uppercase tracking-[0.28em] text-slate-300/70">Preview Workspace</p>
@@ -104,7 +119,7 @@
                                             <p class="mt-2 text-xs font-mono uppercase tracking-[0.22em] text-cyan-100/72">{{ $workspace->id }}</p>
                                             <p class="mt-2">{{ $workspace->summary }}</p>
                                         @else
-                                            <p class="mt-2">The shell is ready, but no Surreal-backed preview workspace is available on this machine yet.</p>
+                                            <p class="mt-2">The runtime is visible now, but no Surreal-backed preview workspace has been materialized on this machine yet.</p>
                                         @endif
                                     </div>
                                 </div>

--- a/tests/Feature/DesktopShellTest.php
+++ b/tests/Feature/DesktopShellTest.php
@@ -10,5 +10,9 @@ test('the desktop shell exposes the katra bootstrap screen', function () {
         ->assertSee('Katra is taking shape as a graph-native workspace')
         ->assertSee('Surreal Foundation')
         ->assertSee('Bundled preview')
-        ->assertSee('local Surreal runtime');
+        ->assertSee('local Surreal runtime')
+        ->assertSee('Runtime')
+        ->assertSee('Binary')
+        ->assertSee('Endpoint')
+        ->assertSee('Unavailable');
 });

--- a/tests/Feature/DesktopShellTest.php
+++ b/tests/Feature/DesktopShellTest.php
@@ -5,6 +5,7 @@ test('the desktop shell exposes the katra bootstrap screen', function () {
     config()->set('surreal.host', '127.0.0.1');
     config()->set('surreal.port', 18999);
     config()->set('surreal.endpoint', 'ws://127.0.0.1:18999');
+    config()->set('surreal.binary', 'surreal-missing-binary-for-desktop-shell-test');
 
     $this->get('/')
         ->assertSuccessful()

--- a/tests/Feature/DesktopShellTest.php
+++ b/tests/Feature/DesktopShellTest.php
@@ -2,6 +2,9 @@
 
 test('the desktop shell exposes the katra bootstrap screen', function () {
     config()->set('surreal.autostart', false);
+    config()->set('surreal.host', '127.0.0.1');
+    config()->set('surreal.port', 18999);
+    config()->set('surreal.endpoint', 'ws://127.0.0.1:18999');
 
     $this->get('/')
         ->assertSuccessful()

--- a/tests/Feature/SurrealWorkspaceModelTest.php
+++ b/tests/Feature/SurrealWorkspaceModelTest.php
@@ -85,6 +85,59 @@ test('the surreal workspace model completes a basic crud flow', function () {
     }
 });
 
+test('the desktop preview workspace can be created through the surreal document store', function () {
+    $client = app(SurrealCliClient::class);
+
+    if (! $client->isAvailable()) {
+        $this->markTestSkipped('The `surreal` CLI is not available in this environment.');
+    }
+
+    $storagePath = storage_path('app/surrealdb/workspace-preview-test-'.Str::uuid());
+
+    File::deleteDirectory($storagePath);
+    File::ensureDirectoryExists(dirname($storagePath));
+
+    try {
+        $server = retryStartingWorkspaceServer($client, $storagePath);
+        $port = $server['port'];
+        $endpoint = $server['endpoint'];
+
+        config()->set('surreal.host', '127.0.0.1');
+        config()->set('surreal.port', $port);
+        config()->set('surreal.endpoint', $endpoint);
+        config()->set('surreal.username', 'root');
+        config()->set('surreal.password', 'root');
+        config()->set('surreal.namespace', 'katra');
+        config()->set('surreal.database', 'workspace_preview_test');
+        config()->set('surreal.storage_engine', 'surrealkv');
+        config()->set('surreal.storage_path', $storagePath);
+        config()->set('surreal.runtime', 'local');
+        config()->set('surreal.autostart', false);
+
+        app()->forgetInstance(SurrealConnection::class);
+        app()->forgetInstance(SurrealRuntimeManager::class);
+        app()->forgetInstance(SurrealDocumentStore::class);
+
+        $workspace = Workspace::desktopPreview();
+
+        expect($workspace->id)->toBe('workspaces:desktop-preview')
+            ->and($workspace->name)->toBe('Desktop Preview Workspace')
+            ->and($workspace->status)->toBe('active');
+
+        $fetchedWorkspace = Workspace::find('desktop-preview');
+
+        expect($fetchedWorkspace)->not->toBeNull()
+            ->and($fetchedWorkspace?->id)->toBe('workspaces:desktop-preview')
+            ->and($fetchedWorkspace?->summary)->toContain('Surreal-backed workspace record');
+    } finally {
+        if (isset($server['process'])) {
+            $server['process']->stop(1);
+        }
+
+        File::deleteDirectory($storagePath);
+    }
+});
+
 /**
  * @return array{endpoint: string, port: int, process: Process}
  */


### PR DESCRIPTION
## Summary
- fix Surreal document-store record queries so hyphenated ids like `desktop-preview` bootstrap correctly
- expose runtime telemetry in the desktop shell so the app shows whether Surreal is running, which binary source is in use, the endpoint, and the local pid when available
- add focused coverage for the desktop-preview workspace flow and stabilize the shell test against local runtime collisions

## Testing
- vendor/bin/pint --dirty --format agent
- php artisan test --compact tests/Feature/DesktopShellTest.php tests/Feature/SurrealWorkspaceModelTest.php
- php artisan tinker --execute ... against the installed app's running Surreal runtime, which returned the preview workspace successfully as `workspaces:desktop-preview`
