### PR TITLE
feat: add Pennant flags for staged desktop UI rollout

### DIFF
--- a/.agents/skills/pennant-development/SKILL.md
+++ b/.agents/skills/pennant-development/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: pennant-development
+description: "Use when working with Laravel Pennant the official Laravel feature flag package. Trigger whenever the query mentions Pennant by name or involves feature flags or feature toggles in a Laravel project. Tasks include defining feature flags checking whether features are active creating class based features in `app/Features` using Blade `@feature` directives scoping flags to users or teams building custom Pennant storage drivers protecting routes with feature flags testing feature flags with Pest or PHPUnit and implementing A B testing or gradual rollouts with feature flags. Do not trigger for generic Laravel configuration authorization policies authentication or non Pennant feature management systems."
+license: MIT
+metadata:
+  author: laravel
+---
+
+# Pennant Features
+
+## When to Apply
+
+Activate this skill when:
+
+- Creating or checking feature flags
+- Managing feature rollouts
+- Implementing A/B testing
+
+## Documentation
+
+Use `search-docs` for detailed Pennant patterns and documentation.
+
+## Basic Usage
+
+### Defining Features
+
+<!-- Defining Features -->
+```php
+use Laravel\Pennant\Feature;
+
+Feature::define('new-dashboard', function (User $user) {
+    return $user->isAdmin();
+});
+```
+
+### Checking Features
+
+<!-- Checking Features -->
+```php
+if (Feature::active('new-dashboard')) {
+    // Feature is active
+}
+
+// With scope
+if (Feature::for($user)->active('new-dashboard')) {
+    // Feature is active for this user
+}
+```
+
+### Blade Directive
+
+<!-- Blade Directive -->
+```blade
+@feature('new-dashboard')
+    <x-new-dashboard />
+@else
+    <x-old-dashboard />
+@endfeature
+```
+
+### Activating / Deactivating
+
+<!-- Activating Features -->
+```php
+Feature::activate('new-dashboard');
+Feature::for($user)->activate('new-dashboard');
+```
+
+## Verification
+
+1. Check feature flag is defined
+2. Test with different scopes/users
+
+## Common Pitfalls
+
+- Forgetting to scope features for specific users/entities
+- Not following existing naming conventions

--- a/.claude/skills/pennant-development/SKILL.md
+++ b/.claude/skills/pennant-development/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: pennant-development
+description: "Use when working with Laravel Pennant the official Laravel feature flag package. Trigger whenever the query mentions Pennant by name or involves feature flags or feature toggles in a Laravel project. Tasks include defining feature flags checking whether features are active creating class based features in `app/Features` using Blade `@feature` directives scoping flags to users or teams building custom Pennant storage drivers protecting routes with feature flags testing feature flags with Pest or PHPUnit and implementing A B testing or gradual rollouts with feature flags. Do not trigger for generic Laravel configuration authorization policies authentication or non Pennant feature management systems."
+license: MIT
+metadata:
+  author: laravel
+---
+
+# Pennant Features
+
+## When to Apply
+
+Activate this skill when:
+
+- Creating or checking feature flags
+- Managing feature rollouts
+- Implementing A/B testing
+
+## Documentation
+
+Use `search-docs` for detailed Pennant patterns and documentation.
+
+## Basic Usage
+
+### Defining Features
+
+<!-- Defining Features -->
+```php
+use Laravel\Pennant\Feature;
+
+Feature::define('new-dashboard', function (User $user) {
+    return $user->isAdmin();
+});
+```
+
+### Checking Features
+
+<!-- Checking Features -->
+```php
+if (Feature::active('new-dashboard')) {
+    // Feature is active
+}
+
+// With scope
+if (Feature::for($user)->active('new-dashboard')) {
+    // Feature is active for this user
+}
+```
+
+### Blade Directive
+
+<!-- Blade Directive -->
+```blade
+@feature('new-dashboard')
+    <x-new-dashboard />
+@else
+    <x-old-dashboard />
+@endfeature
+```
+
+### Activating / Deactivating
+
+<!-- Activating Features -->
+```php
+Feature::activate('new-dashboard');
+Feature::for($user)->activate('new-dashboard');
+```
+
+## Verification
+
+1. Check feature flag is defined
+2. Test with different scopes/users
+
+## Common Pitfalls
+
+- Forgetting to scope features for specific users/entities
+- Not following existing naming conventions

--- a/.cursor/skills/pennant-development/SKILL.md
+++ b/.cursor/skills/pennant-development/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: pennant-development
+description: "Use when working with Laravel Pennant the official Laravel feature flag package. Trigger whenever the query mentions Pennant by name or involves feature flags or feature toggles in a Laravel project. Tasks include defining feature flags checking whether features are active creating class based features in `app/Features` using Blade `@feature` directives scoping flags to users or teams building custom Pennant storage drivers protecting routes with feature flags testing feature flags with Pest or PHPUnit and implementing A B testing or gradual rollouts with feature flags. Do not trigger for generic Laravel configuration authorization policies authentication or non Pennant feature management systems."
+license: MIT
+metadata:
+  author: laravel
+---
+
+# Pennant Features
+
+## When to Apply
+
+Activate this skill when:
+
+- Creating or checking feature flags
+- Managing feature rollouts
+- Implementing A/B testing
+
+## Documentation
+
+Use `search-docs` for detailed Pennant patterns and documentation.
+
+## Basic Usage
+
+### Defining Features
+
+<!-- Defining Features -->
+```php
+use Laravel\Pennant\Feature;
+
+Feature::define('new-dashboard', function (User $user) {
+    return $user->isAdmin();
+});
+```
+
+### Checking Features
+
+<!-- Checking Features -->
+```php
+if (Feature::active('new-dashboard')) {
+    // Feature is active
+}
+
+// With scope
+if (Feature::for($user)->active('new-dashboard')) {
+    // Feature is active for this user
+}
+```
+
+### Blade Directive
+
+<!-- Blade Directive -->
+```blade
+@feature('new-dashboard')
+    <x-new-dashboard />
+@else
+    <x-old-dashboard />
+@endfeature
+```
+
+### Activating / Deactivating
+
+<!-- Activating Features -->
+```php
+Feature::activate('new-dashboard');
+Feature::for($user)->activate('new-dashboard');
+```
+
+## Verification
+
+1. Check feature flag is defined
+2. Test with different scopes/users
+
+## Common Pitfalls
+
+- Forgetting to scope features for specific users/entities
+- Not following existing naming conventions

--- a/.github/skills/pennant-development/SKILL.md
+++ b/.github/skills/pennant-development/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: pennant-development
+description: "Use when working with Laravel Pennant the official Laravel feature flag package. Trigger whenever the query mentions Pennant by name or involves feature flags or feature toggles in a Laravel project. Tasks include defining feature flags checking whether features are active creating class based features in `app/Features` using Blade `@feature` directives scoping flags to users or teams building custom Pennant storage drivers protecting routes with feature flags testing feature flags with Pest or PHPUnit and implementing A B testing or gradual rollouts with feature flags. Do not trigger for generic Laravel configuration authorization policies authentication or non Pennant feature management systems."
+license: MIT
+metadata:
+  author: laravel
+---
+
+# Pennant Features
+
+## When to Apply
+
+Activate this skill when:
+
+- Creating or checking feature flags
+- Managing feature rollouts
+- Implementing A/B testing
+
+## Documentation
+
+Use `search-docs` for detailed Pennant patterns and documentation.
+
+## Basic Usage
+
+### Defining Features
+
+<!-- Defining Features -->
+```php
+use Laravel\Pennant\Feature;
+
+Feature::define('new-dashboard', function (User $user) {
+    return $user->isAdmin();
+});
+```
+
+### Checking Features
+
+<!-- Checking Features -->
+```php
+if (Feature::active('new-dashboard')) {
+    // Feature is active
+}
+
+// With scope
+if (Feature::for($user)->active('new-dashboard')) {
+    // Feature is active for this user
+}
+```
+
+### Blade Directive
+
+<!-- Blade Directive -->
+```blade
+@feature('new-dashboard')
+    <x-new-dashboard />
+@else
+    <x-old-dashboard />
+@endfeature
+```
+
+### Activating / Deactivating
+
+<!-- Activating Features -->
+```php
+Feature::activate('new-dashboard');
+Feature::for($user)->activate('new-dashboard');
+```
+
+## Verification
+
+1. Check feature flag is defined
+2. Test with different scopes/users
+
+## Common Pitfalls
+
+- Forgetting to scope features for specific users/entities
+- Not following existing naming conventions

--- a/.junie/skills/pennant-development/SKILL.md
+++ b/.junie/skills/pennant-development/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: pennant-development
+description: "Use when working with Laravel Pennant the official Laravel feature flag package. Trigger whenever the query mentions Pennant by name or involves feature flags or feature toggles in a Laravel project. Tasks include defining feature flags checking whether features are active creating class based features in `app/Features` using Blade `@feature` directives scoping flags to users or teams building custom Pennant storage drivers protecting routes with feature flags testing feature flags with Pest or PHPUnit and implementing A B testing or gradual rollouts with feature flags. Do not trigger for generic Laravel configuration authorization policies authentication or non Pennant feature management systems."
+license: MIT
+metadata:
+  author: laravel
+---
+
+# Pennant Features
+
+## When to Apply
+
+Activate this skill when:
+
+- Creating or checking feature flags
+- Managing feature rollouts
+- Implementing A/B testing
+
+## Documentation
+
+Use `search-docs` for detailed Pennant patterns and documentation.
+
+## Basic Usage
+
+### Defining Features
+
+<!-- Defining Features -->
+```php
+use Laravel\Pennant\Feature;
+
+Feature::define('new-dashboard', function (User $user) {
+    return $user->isAdmin();
+});
+```
+
+### Checking Features
+
+<!-- Checking Features -->
+```php
+if (Feature::active('new-dashboard')) {
+    // Feature is active
+}
+
+// With scope
+if (Feature::for($user)->active('new-dashboard')) {
+    // Feature is active for this user
+}
+```
+
+### Blade Directive
+
+<!-- Blade Directive -->
+```blade
+@feature('new-dashboard')
+    <x-new-dashboard />
+@else
+    <x-old-dashboard />
+@endfeature
+```
+
+### Activating / Deactivating
+
+<!-- Activating Features -->
+```php
+Feature::activate('new-dashboard');
+Feature::for($user)->activate('new-dashboard');
+```
+
+## Verification
+
+1. Check feature flag is defined
+2. Test with different scopes/users
+
+## Common Pitfalls
+
+- Forgetting to scope features for specific users/entities
+- Not following existing naming conventions

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ This application is a Laravel application and its main Laravel ecosystems packag
 
 - php - 8.4
 - laravel/framework (LARAVEL) - v13
+- laravel/pennant (PENNANT) - v1
 - laravel/prompts (PROMPTS) - v0
 - laravel/boost (BOOST) - v2
 - laravel/mcp (MCP) - v0
@@ -24,6 +25,7 @@ This application is a Laravel application and its main Laravel ecosystems packag
 
 This project has domain-specific skills available. You MUST activate the relevant skill whenever you work in that domain—don't wait until you're stuck.
 
+- `pennant-development` — Use when working with Laravel Pennant the official Laravel feature flag package. Trigger whenever the query mentions Pennant by name or involves feature flags or feature toggles in a Laravel project. Tasks include defining feature flags checking whether features are active creating class based features in `app/Features` using Blade `@feature` directives scoping flags to users or teams building custom Pennant storage drivers protecting routes with feature flags testing feature flags with Pest or PHPUnit and implementing A B testing or gradual rollouts with feature flags. Do not trigger for generic Laravel configuration authorization policies authentication or non Pennant feature management systems.
 - `pest-testing` — Use this skill for Pest PHP testing in Laravel projects only. Trigger whenever any test is being written, edited, fixed, or refactored — including fixing tests that broke after a code change, adding assertions, converting PHPUnit to Pest, adding datasets, and TDD workflows. Always activate when the user asks how to write something in Pest, mentions test files or directories (tests/Feature, tests/Unit, tests/Browser), or needs browser testing, smoke testing multiple pages for JS errors, or architecture tests. Covers: it()/expect() syntax, datasets, mocking, browser testing (visit/click/fill), smoke testing, arch(), Livewire component tests, RefreshDatabase, and all Pest 4 features. Do not use for factories, seeders, migrations, controllers, models, or non-test PHP code.
 - `tailwindcss-development` — Always invoke when the user's message includes 'tailwind' in any form. Also invoke for: building responsive grid layouts (multi-column card grids, product grids), flex/grid page structures (dashboards with sidebars, fixed topbars, mobile-toggle navs), styling UI components (cards, tables, navbars, pricing sections, forms, inputs, badges), adding dark mode variants, fixing spacing or typography, and Tailwind v3/v4 work. The core use case: writing or fixing Tailwind utility classes in HTML templates (Blade, JSX, Vue). Skip for backend PHP logic, database queries, API routes, JavaScript with no HTML/CSS component, CSS file audits, build tool configuration, and vanilla CSS.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,7 @@ This application is a Laravel application and its main Laravel ecosystems packag
 
 - php - 8.4
 - laravel/framework (LARAVEL) - v13
+- laravel/pennant (PENNANT) - v1
 - laravel/prompts (PROMPTS) - v0
 - laravel/boost (BOOST) - v2
 - laravel/mcp (MCP) - v0
@@ -24,6 +25,7 @@ This application is a Laravel application and its main Laravel ecosystems packag
 
 This project has domain-specific skills available. You MUST activate the relevant skill whenever you work in that domain—don't wait until you're stuck.
 
+- `pennant-development` — Use when working with Laravel Pennant the official Laravel feature flag package. Trigger whenever the query mentions Pennant by name or involves feature flags or feature toggles in a Laravel project. Tasks include defining feature flags checking whether features are active creating class based features in `app/Features` using Blade `@feature` directives scoping flags to users or teams building custom Pennant storage drivers protecting routes with feature flags testing feature flags with Pest or PHPUnit and implementing A B testing or gradual rollouts with feature flags. Do not trigger for generic Laravel configuration authorization policies authentication or non Pennant feature management systems.
 - `pest-testing` — Use this skill for Pest PHP testing in Laravel projects only. Trigger whenever any test is being written, edited, fixed, or refactored — including fixing tests that broke after a code change, adding assertions, converting PHPUnit to Pest, adding datasets, and TDD workflows. Always activate when the user asks how to write something in Pest, mentions test files or directories (tests/Feature, tests/Unit, tests/Browser), or needs browser testing, smoke testing multiple pages for JS errors, or architecture tests. Covers: it()/expect() syntax, datasets, mocking, browser testing (visit/click/fill), smoke testing, arch(), Livewire component tests, RefreshDatabase, and all Pest 4 features. Do not use for factories, seeders, migrations, controllers, models, or non-test PHP code.
 - `tailwindcss-development` — Always invoke when the user's message includes 'tailwind' in any form. Also invoke for: building responsive grid layouts (multi-column card grids, product grids), flex/grid page structures (dashboards with sidebars, fixed topbars, mobile-toggle navs), styling UI components (cards, tables, navbars, pricing sections, forms, inputs, badges), adding dark mode variants, fixing spacing or typography, and Tailwind v3/v4 work. The core use case: writing or fixing Tailwind utility classes in HTML templates (Blade, JSX, Vue). Skip for backend PHP logic, database queries, API routes, JavaScript with no HTML/CSS component, CSS file audits, build tool configuration, and vanilla CSS.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,3 +145,15 @@ This means contributors should think of pull request titles and merge commits as
 - if a pull request contains mixed work, choose the title based on the highest-impact user-facing change
 - if a pull request includes a breaking change, make that explicit in the title or body
 - if release behavior becomes more specific later, this policy should be updated to match the automation
+
+## Feature Flags
+
+Desktop UI rollout work should use Laravel Pennant instead of ad hoc booleans or environment checks.
+
+Current convention:
+
+- desktop UI rollout flags live in `App\Features\Desktop\*`
+- stored Pennant names should use the `ui.desktop.*` namespace
+- desktop shell code should check rollout flags through feature classes or the `App\Support\Features\DesktopUi` helper, not raw string literals scattered through Blade or controller code
+
+This keeps staged UI work explicit, testable, and easy to disable while mock or feedback-only surfaces are still settling.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -11,6 +11,7 @@ This application is a Laravel application and its main Laravel ecosystems packag
 
 - php - 8.4
 - laravel/framework (LARAVEL) - v13
+- laravel/pennant (PENNANT) - v1
 - laravel/prompts (PROMPTS) - v0
 - laravel/boost (BOOST) - v2
 - laravel/mcp (MCP) - v0
@@ -24,6 +25,7 @@ This application is a Laravel application and its main Laravel ecosystems packag
 
 This project has domain-specific skills available. You MUST activate the relevant skill whenever you work in that domain—don't wait until you're stuck.
 
+- `pennant-development` — Use when working with Laravel Pennant the official Laravel feature flag package. Trigger whenever the query mentions Pennant by name or involves feature flags or feature toggles in a Laravel project. Tasks include defining feature flags checking whether features are active creating class based features in `app/Features` using Blade `@feature` directives scoping flags to users or teams building custom Pennant storage drivers protecting routes with feature flags testing feature flags with Pest or PHPUnit and implementing A B testing or gradual rollouts with feature flags. Do not trigger for generic Laravel configuration authorization policies authentication or non Pennant feature management systems.
 - `pest-testing` — Use this skill for Pest PHP testing in Laravel projects only. Trigger whenever any test is being written, edited, fixed, or refactored — including fixing tests that broke after a code change, adding assertions, converting PHPUnit to Pest, adding datasets, and TDD workflows. Always activate when the user asks how to write something in Pest, mentions test files or directories (tests/Feature, tests/Unit, tests/Browser), or needs browser testing, smoke testing multiple pages for JS errors, or architecture tests. Covers: it()/expect() syntax, datasets, mocking, browser testing (visit/click/fill), smoke testing, arch(), Livewire component tests, RefreshDatabase, and all Pest 4 features. Do not use for factories, seeders, migrations, controllers, models, or non-test PHP code.
 - `tailwindcss-development` — Always invoke when the user's message includes 'tailwind' in any form. Also invoke for: building responsive grid layouts (multi-column card grids, product grids), flex/grid page structures (dashboards with sidebars, fixed topbars, mobile-toggle navs), styling UI components (cards, tables, navbars, pricing sections, forms, inputs, badges), adding dark mode variants, fixing spacing or typography, and Tailwind v3/v4 work. The core use case: writing or fixing Tailwind utility classes in HTML templates (Blade, JSX, Vue). Skip for backend PHP logic, database queries, API routes, JavaScript with no HTML/CSS component, CSS file audits, build tool configuration, and vanilla CSS.
 

--- a/app/Features/Desktop/AgentPresence.php
+++ b/app/Features/Desktop/AgentPresence.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Features\Desktop;
+
+use Laravel\Pennant\Attributes\Name;
+
+#[Name('ui.desktop.agent-presence')]
+class AgentPresence
+{
+    /**
+     * Resolve the feature's initial value.
+     */
+    public function resolve(mixed $scope): mixed
+    {
+        return false;
+    }
+}

--- a/app/Features/Desktop/ArtifactSurfaces.php
+++ b/app/Features/Desktop/ArtifactSurfaces.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Features\Desktop;
+
+use Laravel\Pennant\Attributes\Name;
+
+#[Name('ui.desktop.artifact-surfaces')]
+class ArtifactSurfaces
+{
+    /**
+     * Resolve the feature's initial value.
+     */
+    public function resolve(mixed $scope): mixed
+    {
+        return false;
+    }
+}

--- a/app/Features/Desktop/ConversationChannels.php
+++ b/app/Features/Desktop/ConversationChannels.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Features\Desktop;
+
+use Laravel\Pennant\Attributes\Name;
+
+#[Name('ui.desktop.conversation-channels')]
+class ConversationChannels
+{
+    /**
+     * Resolve the feature's initial value.
+     */
+    public function resolve(mixed $scope): mixed
+    {
+        return false;
+    }
+}

--- a/app/Features/Desktop/MvpShell.php
+++ b/app/Features/Desktop/MvpShell.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Features\Desktop;
+
+use Laravel\Pennant\Attributes\Name;
+
+#[Name('ui.desktop.mvp-shell')]
+class MvpShell
+{
+    /**
+     * Resolve the feature's initial value.
+     */
+    public function resolve(mixed $scope): mixed
+    {
+        return true;
+    }
+}

--- a/app/Features/Desktop/TaskSurfaces.php
+++ b/app/Features/Desktop/TaskSurfaces.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Features\Desktop;
+
+use Laravel\Pennant\Attributes\Name;
+
+#[Name('ui.desktop.task-surfaces')]
+class TaskSurfaces
+{
+    /**
+     * Resolve the feature's initial value.
+     */
+    public function resolve(mixed $scope): mixed
+    {
+        return false;
+    }
+}

--- a/app/Features/Desktop/WorkspaceNavigation.php
+++ b/app/Features/Desktop/WorkspaceNavigation.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Features\Desktop;
+
+use Laravel\Pennant\Attributes\Name;
+
+#[Name('ui.desktop.workspace-navigation')]
+class WorkspaceNavigation
+{
+    /**
+     * Resolve the feature's initial value.
+     */
+    public function resolve(mixed $scope): mixed
+    {
+        return false;
+    }
+}

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Controllers;
 
-use App\Features\Desktop\WorkspaceNavigation;
 use App\Models\Workspace;
 use App\Services\Surreal\SurrealCliClient;
 use App\Services\Surreal\SurrealConnection;
@@ -27,8 +26,7 @@ class HomeController extends Controller
             ['label' => 'Binary', 'value' => $this->binaryLabel($connection, $client)],
             ['label' => 'Endpoint', 'value' => $connection->endpoint],
         ];
-        $desktopUiFlags = DesktopUi::states();
-        $workspaceNavigationEnabled = DesktopUi::enabled($desktopUiFlags, WorkspaceNavigation::class);
+        $workspaceNavigationEnabled = DesktopUi::workspaceNavigationEnabled();
 
         try {
             $runtimeReady = $runtimeManager->ensureReady();
@@ -46,7 +44,6 @@ class HomeController extends Controller
                     : sprintf('The remote Surreal runtime is not responding at %s.', $connection->endpoint);
 
                 return view('welcome', [
-                    'desktopUiFlags' => $desktopUiFlags,
                     'workspaceNavigationEnabled' => $workspaceNavigationEnabled,
                     'workspace' => $workspace,
                     'surrealStatus' => $surrealStatus,
@@ -71,7 +68,6 @@ class HomeController extends Controller
         }
 
         return view('welcome', [
-            'desktopUiFlags' => $desktopUiFlags,
             'workspaceNavigationEnabled' => $workspaceNavigationEnabled,
             'workspace' => $workspace,
             'surrealStatus' => $surrealStatus,

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -6,6 +6,7 @@ use App\Models\Workspace;
 use App\Services\Surreal\SurrealCliClient;
 use App\Services\Surreal\SurrealConnection;
 use App\Services\Surreal\SurrealRuntimeManager;
+use App\Support\Features\DesktopUi;
 use Illuminate\Support\Str;
 use Illuminate\View\View;
 use RuntimeException;
@@ -25,6 +26,8 @@ class HomeController extends Controller
             ['label' => 'Binary', 'value' => $this->binaryLabel($connection, $client)],
             ['label' => 'Endpoint', 'value' => $connection->endpoint],
         ];
+        $desktopUiFlags = DesktopUi::states();
+        $workspaceNavigationEnabled = DesktopUi::workspaceNavigationEnabled();
 
         try {
             $runtimeReady = $runtimeManager->ensureReady();
@@ -42,6 +45,8 @@ class HomeController extends Controller
                     : sprintf('The remote Surreal runtime is not responding at %s.', $connection->endpoint);
 
                 return view('welcome', [
+                    'desktopUiFlags' => $desktopUiFlags,
+                    'workspaceNavigationEnabled' => $workspaceNavigationEnabled,
                     'workspace' => $workspace,
                     'surrealStatus' => $surrealStatus,
                     'surrealMessage' => $surrealMessage,
@@ -65,6 +70,8 @@ class HomeController extends Controller
         }
 
         return view('welcome', [
+            'desktopUiFlags' => $desktopUiFlags,
+            'workspaceNavigationEnabled' => $workspaceNavigationEnabled,
             'workspace' => $workspace,
             'surrealStatus' => $surrealStatus,
             'surrealMessage' => $surrealMessage,

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Features\Desktop\WorkspaceNavigation;
 use App\Models\Workspace;
 use App\Services\Surreal\SurrealCliClient;
 use App\Services\Surreal\SurrealConnection;
@@ -27,7 +28,7 @@ class HomeController extends Controller
             ['label' => 'Endpoint', 'value' => $connection->endpoint],
         ];
         $desktopUiFlags = DesktopUi::states();
-        $workspaceNavigationEnabled = DesktopUi::workspaceNavigationEnabled();
+        $workspaceNavigationEnabled = DesktopUi::enabled($desktopUiFlags, WorkspaceNavigation::class);
 
         try {
             $runtimeReady = $runtimeManager->ensureReady();

--- a/app/Support/Features/DesktopUi.php
+++ b/app/Support/Features/DesktopUi.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace App\Support\Features;
+
+use App\Features\Desktop\AgentPresence;
+use App\Features\Desktop\ArtifactSurfaces;
+use App\Features\Desktop\ConversationChannels;
+use App\Features\Desktop\MvpShell;
+use App\Features\Desktop\TaskSurfaces;
+use App\Features\Desktop\WorkspaceNavigation;
+use Laravel\Pennant\Feature;
+
+class DesktopUi
+{
+    /**
+     * The Pennant scope used for desktop UI rollout flags.
+     */
+    public static function scope(): string
+    {
+        return 'desktop-ui';
+    }
+
+    /**
+     * The ordered list of desktop UI rollout features.
+     *
+     * @return list<class-string>
+     */
+    public static function features(): array
+    {
+        return [
+            MvpShell::class,
+            WorkspaceNavigation::class,
+            ConversationChannels::class,
+            TaskSurfaces::class,
+            ArtifactSurfaces::class,
+            AgentPresence::class,
+        ];
+    }
+
+    /**
+     * Determine if the given desktop UI feature is active.
+     *
+     * @param  class-string  $feature
+     */
+    public static function active(string $feature): bool
+    {
+        return Feature::for(self::scope())->active($feature);
+    }
+
+    public static function mvpShellEnabled(): bool
+    {
+        return self::active(MvpShell::class);
+    }
+
+    public static function workspaceNavigationEnabled(): bool
+    {
+        return self::active(WorkspaceNavigation::class);
+    }
+
+    public static function conversationChannelsEnabled(): bool
+    {
+        return self::active(ConversationChannels::class);
+    }
+
+    public static function taskSurfacesEnabled(): bool
+    {
+        return self::active(TaskSurfaces::class);
+    }
+
+    public static function artifactSurfacesEnabled(): bool
+    {
+        return self::active(ArtifactSurfaces::class);
+    }
+
+    public static function agentPresenceEnabled(): bool
+    {
+        return self::active(AgentPresence::class);
+    }
+
+    /**
+     * Resolve the current desktop UI rollout state.
+     *
+     * @return array<string, mixed>
+     */
+    public static function states(): array
+    {
+        return Feature::for(self::scope())->values(self::features());
+    }
+}

--- a/app/Support/Features/DesktopUi.php
+++ b/app/Support/Features/DesktopUi.php
@@ -8,7 +8,11 @@ use App\Features\Desktop\ConversationChannels;
 use App\Features\Desktop\MvpShell;
 use App\Features\Desktop\TaskSurfaces;
 use App\Features\Desktop\WorkspaceNavigation;
+use Illuminate\Database\QueryException;
+use Illuminate\Support\Facades\Schema;
+use Laravel\Pennant\Attributes\Name;
 use Laravel\Pennant\Feature;
+use ReflectionClass;
 
 class DesktopUi
 {
@@ -44,7 +48,18 @@ class DesktopUi
      */
     public static function active(string $feature): bool
     {
-        return Feature::for(self::scope())->active($feature);
+        return self::enabled(self::states(), $feature);
+    }
+
+    /**
+     * Determine if the given desktop UI feature is enabled in the provided state map.
+     *
+     * @param  array<string, mixed>  $states
+     * @param  class-string  $feature
+     */
+    public static function enabled(array $states, string $feature): bool
+    {
+        return (bool) ($states[self::featureName($feature)] ?? self::defaultValue($feature));
     }
 
     public static function mvpShellEnabled(): bool
@@ -84,6 +99,71 @@ class DesktopUi
      */
     public static function states(): array
     {
-        return Feature::for(self::scope())->values(self::features());
+        if (! self::databaseStoreReady()) {
+            return self::defaultStates();
+        }
+
+        try {
+            return Feature::for(self::scope())->values(self::features());
+        } catch (QueryException $exception) {
+            if (self::missingFeatureTable($exception)) {
+                return self::defaultStates();
+            }
+
+            throw $exception;
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private static function defaultStates(): array
+    {
+        $states = [];
+
+        foreach (self::features() as $feature) {
+            $states[self::featureName($feature)] = self::defaultValue($feature);
+        }
+
+        return $states;
+    }
+
+    /**
+     * @param  class-string  $feature
+     */
+    private static function defaultValue(string $feature): mixed
+    {
+        return app($feature)->resolve(self::scope());
+    }
+
+    /**
+     * @param  class-string  $feature
+     */
+    private static function featureName(string $feature): string
+    {
+        $attributes = (new ReflectionClass($feature))->getAttributes(Name::class);
+
+        if ($attributes === []) {
+            return $feature;
+        }
+
+        return $attributes[0]->newInstance()->name;
+    }
+
+    private static function databaseStoreReady(): bool
+    {
+        if (config('pennant.default') !== 'database') {
+            return true;
+        }
+
+        $connection = config('pennant.stores.database.connection');
+        $table = config('pennant.stores.database.table', 'features');
+
+        return Schema::connection($connection)->hasTable($table);
+    }
+
+    private static function missingFeatureTable(QueryException $exception): bool
+    {
+        return str_contains(strtolower($exception->getMessage()), 'no such table: features');
     }
 }

--- a/boost.json
+++ b/boost.json
@@ -15,6 +15,7 @@
     "nightwatch_mcp": false,
     "sail": false,
     "skills": [
+        "pennant-development",
         "pest-testing",
         "tailwindcss-development"
     ]

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
     "require": {
         "php": "^8.4",
         "laravel/framework": "^13.0",
+        "laravel/pennant": "^1.0",
         "laravel/tinker": "^3.0",
         "nativephp/desktop": "dev-l13-compatibility"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9c2f3b85f6dc488a090ace54293830ef",
+    "content-hash": "b1b28d182bb883b528f5356b08231224",
     "packages": [
         {
             "name": "brick/math",
@@ -1273,6 +1273,82 @@
                 "source": "https://github.com/laravel/framework"
             },
             "time": "2026-03-18T17:10:25+00:00"
+        },
+        {
+            "name": "laravel/pennant",
+            "version": "v1.22.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/pennant.git",
+                "reference": "e50099c8af83bffde5faea40480e4d77fc8a8b2a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/pennant/zipball/e50099c8af83bffde5faea40480e4d77fc8a8b2a",
+                "reference": "e50099c8af83bffde5faea40480e4d77fc8a8b2a",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/console": "^10.0|^11.0|^12.0|^13.0",
+                "illuminate/container": "^10.0|^11.0|^12.0|^13.0",
+                "illuminate/contracts": "^10.0|^11.0|^12.0|^13.0",
+                "illuminate/database": "^10.0|^11.0|^12.0|^13.0",
+                "illuminate/queue": "^10.0|^11.0|^12.0|^13.0",
+                "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
+                "php": "^8.1",
+                "symfony/console": "^6.0|^7.0|^8.0",
+                "symfony/finder": "^6.0|^7.0|^8.0"
+            },
+            "require-dev": {
+                "laravel/octane": "^1.4|^2.0",
+                "orchestra/testbench": "^8.36|^9.15|^10.8|^11.0",
+                "phpstan/phpstan": "^1.10"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "Feature": "Laravel\\Pennant\\Feature"
+                    },
+                    "providers": [
+                        "Laravel\\Pennant\\PennantServiceProvider"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/helpers.php"
+                ],
+                "psr-4": {
+                    "Laravel\\Pennant\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "A simple, lightweight library for managing feature flags.",
+            "homepage": "https://github.com/laravel/pennant",
+            "keywords": [
+                "feature",
+                "flags",
+                "laravel",
+                "pennant"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/pennant/issues",
+                "source": "https://github.com/laravel/pennant"
+            },
+            "time": "2026-03-18T10:27:27+00:00"
         },
         {
             "name": "laravel/prompts",

--- a/config/pennant.php
+++ b/config/pennant.php
@@ -1,0 +1,44 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default Pennant Store
+    |--------------------------------------------------------------------------
+    |
+    | Here you will specify the default store that Pennant should use when
+    | storing and resolving feature flag values. Pennant ships with the
+    | ability to store flag values in an in-memory array or database.
+    |
+    | Supported: "array", "database"
+    |
+    */
+
+    'default' => env('PENNANT_STORE', 'database'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Pennant Stores
+    |--------------------------------------------------------------------------
+    |
+    | Here you may configure each of the stores that should be available to
+    | Pennant. These stores shall be used to store resolved feature flag
+    | values - you may configure as many as your application requires.
+    |
+    */
+
+    'stores' => [
+
+        'array' => [
+            'driver' => 'array',
+        ],
+
+        'database' => [
+            'driver' => 'database',
+            'connection' => null,
+            'table' => 'features',
+        ],
+
+    ],
+];

--- a/database/migrations/2026_03_21_004800_create_features_table.php
+++ b/database/migrations/2026_03_21_004800_create_features_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Laravel\Pennant\Migrations\PennantMigration;
+
+return new class extends PennantMigration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('features', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('scope');
+            $table->text('value');
+            $table->timestamps();
+
+            $table->unique(['name', 'scope']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('features');
+    }
+};

--- a/database/migrations/2026_03_21_004800_create_features_table.php
+++ b/database/migrations/2026_03_21_004800_create_features_table.php
@@ -11,7 +11,7 @@ return new class extends PennantMigration
      */
     public function up(): void
     {
-        Schema::create('features', function (Blueprint $table) {
+        Schema::create($this->tableName(), function (Blueprint $table) {
             $table->id();
             $table->string('name');
             $table->string('scope');
@@ -27,6 +27,11 @@ return new class extends PennantMigration
      */
     public function down(): void
     {
-        Schema::dropIfExists('features');
+        Schema::dropIfExists($this->tableName());
+    }
+
+    private function tableName(): string
+    {
+        return config('pennant.stores.database.table', 'features');
     }
 };

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -157,6 +157,15 @@
                                 </ul>
                             </div>
 
+                            @if ($workspaceNavigationEnabled)
+                                <div class="rounded-[28px] border border-fuchsia-200/15 bg-fuchsia-300/10 p-5">
+                                    <p class="font-mono text-[11px] uppercase tracking-[0.28em] text-fuchsia-100/78">Workspace navigation pilot</p>
+                                    <p class="mt-3 text-sm leading-7 text-slate-200/82">
+                                        A staged desktop navigation surface is enabled for feedback. This area exists behind Pennant so mock or incomplete UI can be rolled out deliberately instead of becoming permanent by accident.
+                                    </p>
+                                </div>
+                            @endif
+
                             <div class="rounded-[28px] border border-amber-200/12 bg-amber-300/8 p-5">
                                 <p class="font-mono text-[11px] uppercase tracking-[0.28em] text-amber-100/78">Compatibility note</p>
                                 <p class="mt-3 text-sm leading-7 text-slate-200/82">

--- a/tests/Feature/DesktopShellTest.php
+++ b/tests/Feature/DesktopShellTest.php
@@ -22,3 +22,24 @@ test('the desktop shell exposes the katra bootstrap screen', function () {
         ->assertSee('Unavailable')
         ->assertDontSee('Workspace navigation pilot');
 });
+
+test('the desktop shell falls back to default feature flags before the Pennant table exists', function () {
+    config()->set('pennant.default', 'database');
+    config()->set('pennant.stores.database.connection', 'pennant_fallback');
+    config()->set('database.connections.pennant_fallback', [
+        'driver' => 'sqlite',
+        'database' => ':memory:',
+        'prefix' => '',
+        'foreign_key_constraints' => true,
+    ]);
+    config()->set('surreal.autostart', false);
+    config()->set('surreal.host', '127.0.0.1');
+    config()->set('surreal.port', 18999);
+    config()->set('surreal.endpoint', 'ws://127.0.0.1:18999');
+    config()->set('surreal.binary', 'surreal-missing-binary-for-desktop-shell-test');
+
+    $this->get('/')
+        ->assertSuccessful()
+        ->assertSee('NativePHP desktop shell')
+        ->assertDontSee('Workspace navigation pilot');
+});

--- a/tests/Feature/DesktopShellTest.php
+++ b/tests/Feature/DesktopShellTest.php
@@ -1,6 +1,7 @@
 <?php
 
 test('the desktop shell exposes the katra bootstrap screen', function () {
+    config()->set('pennant.default', 'array');
     config()->set('surreal.autostart', false);
     config()->set('surreal.host', '127.0.0.1');
     config()->set('surreal.port', 18999);
@@ -18,5 +19,6 @@ test('the desktop shell exposes the katra bootstrap screen', function () {
         ->assertSee('Runtime')
         ->assertSee('Binary')
         ->assertSee('Endpoint')
-        ->assertSee('Unavailable');
+        ->assertSee('Unavailable')
+        ->assertDontSee('Workspace navigation pilot');
 });

--- a/tests/Feature/DesktopUiFeatureFlagTest.php
+++ b/tests/Feature/DesktopUiFeatureFlagTest.php
@@ -1,0 +1,58 @@
+<?php
+
+use App\Features\Desktop\AgentPresence;
+use App\Features\Desktop\ArtifactSurfaces;
+use App\Features\Desktop\ConversationChannels;
+use App\Features\Desktop\MvpShell;
+use App\Features\Desktop\TaskSurfaces;
+use App\Features\Desktop\WorkspaceNavigation;
+use App\Support\Features\DesktopUi;
+use Laravel\Pennant\Attributes\Name;
+use Laravel\Pennant\Feature;
+
+test('desktop ui rollout uses the desktop pennant scope and feature naming convention', function () {
+    config()->set('pennant.default', 'array');
+
+    expect(DesktopUi::scope())->toBe('desktop-ui')
+        ->and(DesktopUi::features())->toBe([
+            MvpShell::class,
+            WorkspaceNavigation::class,
+            ConversationChannels::class,
+            TaskSurfaces::class,
+            ArtifactSurfaces::class,
+            AgentPresence::class,
+        ]);
+
+    foreach (DesktopUi::features() as $feature) {
+        $attributes = (new ReflectionClass($feature))->getAttributes(Name::class);
+
+        expect($attributes)->toHaveCount(1)
+            ->and($attributes[0]->newInstance()->name)->toStartWith('ui.desktop.');
+    }
+});
+
+test('desktop ui rollout defaults are resolved through pennant', function () {
+    config()->set('pennant.default', 'array');
+
+    expect(DesktopUi::states())->toMatchArray([
+        'ui.desktop.mvp-shell' => true,
+        'ui.desktop.workspace-navigation' => false,
+        'ui.desktop.conversation-channels' => false,
+        'ui.desktop.task-surfaces' => false,
+        'ui.desktop.artifact-surfaces' => false,
+        'ui.desktop.agent-presence' => false,
+    ]);
+});
+
+test('desktop ui surfaces can be staged on without changing the shell implementation', function () {
+    config()->set('pennant.default', 'array');
+
+    Feature::for(DesktopUi::scope())->activate(WorkspaceNavigation::class);
+
+    expect(DesktopUi::active(WorkspaceNavigation::class))->toBeTrue()
+        ->and(DesktopUi::states()['ui.desktop.workspace-navigation'])->toBeTrue();
+
+    $this->get('/')
+        ->assertSuccessful()
+        ->assertSee('Workspace navigation pilot');
+});

--- a/tests/Feature/DesktopUiFeatureFlagTest.php
+++ b/tests/Feature/DesktopUiFeatureFlagTest.php
@@ -44,6 +44,26 @@ test('desktop ui rollout defaults are resolved through pennant', function () {
     ]);
 });
 
+test('desktop ui rollout falls back to defaults when the Pennant database store is not ready', function () {
+    config()->set('pennant.default', 'database');
+    config()->set('pennant.stores.database.connection', 'pennant_fallback');
+    config()->set('database.connections.pennant_fallback', [
+        'driver' => 'sqlite',
+        'database' => ':memory:',
+        'prefix' => '',
+        'foreign_key_constraints' => true,
+    ]);
+
+    expect(DesktopUi::states())->toMatchArray([
+        'ui.desktop.mvp-shell' => true,
+        'ui.desktop.workspace-navigation' => false,
+        'ui.desktop.conversation-channels' => false,
+        'ui.desktop.task-surfaces' => false,
+        'ui.desktop.artifact-surfaces' => false,
+        'ui.desktop.agent-presence' => false,
+    ]);
+});
+
 test('desktop ui surfaces can be staged on without changing the shell implementation', function () {
     config()->set('pennant.default', 'array');
 


### PR DESCRIPTION
## Summary
- add Laravel Pennant with desktop-scoped UI rollout features and published config/migration
- add a shared DesktopUi helper, staged shell gate, and tests for naming/defaults/activation
- sync Boost agent metadata and Pennant skill docs with the new dependency

## Testing
- vendor/bin/pint --dirty --format agent
- php artisan test --compact tests/Feature/DesktopUiFeatureFlagTest.php tests/Feature/DesktopShellTest.php

Closes #99