### PR TITLE
feat: install the Laravel AI package

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -70,6 +70,11 @@ NATIVEPHP_APP_AUTHOR=DevOption
 NATIVEPHP_APP_DESCRIPTION="Katra is an open source, graph-native AI workspace for conversations, tasks, and collaborative intelligence."
 NATIVEPHP_APP_WEBSITE=https://github.com/devoption/katra
 
+AI_DEFAULT_PROVIDER=openai
+OPENAI_API_KEY=
+OLLAMA_API_KEY=
+OLLAMA_BASE_URL=http://localhost:11434
+
 SURREAL_DRIVER=cli
 SURREAL_RUNTIME=local
 SURREAL_AUTOSTART=true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@ The Laravel Boost guidelines are specifically curated by Laravel maintainers for
 This application is a Laravel application and its main Laravel ecosystems package & versions are below. You are an expert with them all. Ensure you abide by these specific packages & versions.
 
 - php - 8.4
+- laravel/ai (AI) - v0
 - laravel/framework (LARAVEL) - v13
 - laravel/pennant (PENNANT) - v1
 - laravel/prompts (PROMPTS) - v0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,7 @@ The Laravel Boost guidelines are specifically curated by Laravel maintainers for
 This application is a Laravel application and its main Laravel ecosystems package & versions are below. You are an expert with them all. Ensure you abide by these specific packages & versions.
 
 - php - 8.4
+- laravel/ai (AI) - v0
 - laravel/framework (LARAVEL) - v13
 - laravel/pennant (PENNANT) - v1
 - laravel/prompts (PROMPTS) - v0

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -10,6 +10,7 @@ The Laravel Boost guidelines are specifically curated by Laravel maintainers for
 This application is a Laravel application and its main Laravel ecosystems package & versions are below. You are an expert with them all. Ensure you abide by these specific packages & versions.
 
 - php - 8.4
+- laravel/ai (AI) - v0
 - laravel/framework (LARAVEL) - v13
 - laravel/pennant (PENNANT) - v1
 - laravel/prompts (PROMPTS) - v0

--- a/README.md
+++ b/README.md
@@ -66,6 +66,16 @@ composer native:dev
 
 That path installs dependencies, prepares the Laravel app, bootstraps NativePHP, and starts the local desktop development loop.
 
+### Configure AI Providers
+
+The Laravel AI SDK is installed and its conversation storage migrations are part of the application now.
+
+- For hosted model access, set `OPENAI_API_KEY` and leave `AI_DEFAULT_PROVIDER=openai`.
+- For local model experiments, set `AI_DEFAULT_PROVIDER=ollama` and point `OLLAMA_BASE_URL` at your local Ollama instance.
+- Additional provider keys are available in [config/ai.php](config/ai.php) if you want to swap providers later.
+
+The current AI foundation test uses agent fakes, so the repo test suite does not require live provider credentials just to verify the integration.
+
 ## Planning Docs
 
 - [Katra v2 Overview](docs/v2-overview.md)

--- a/README.md
+++ b/README.md
@@ -72,7 +72,8 @@ The Laravel AI SDK is installed and its conversation storage migrations are part
 
 - For hosted model access, set `OPENAI_API_KEY` and leave `AI_DEFAULT_PROVIDER=openai`.
 - For local model experiments, set `AI_DEFAULT_PROVIDER=ollama` and point `OLLAMA_BASE_URL` at your local Ollama instance.
-- Additional provider keys are available in [config/ai.php](config/ai.php) if you want to swap providers later.
+- Additional provider keys and per-capability defaults are available in [config/ai.php](config/ai.php) if you want to swap providers later.
+- Some capabilities still default to specific providers like Gemini or Cohere, so if you want everything to follow your primary provider you should update the operation-specific defaults in `config/ai.php` as well.
 
 The current AI foundation test uses agent fakes, so the repo test suite does not require live provider credentials just to verify the integration.
 

--- a/app/Ai/Agents/WorkspaceGuide.php
+++ b/app/Ai/Agents/WorkspaceGuide.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Ai\Agents;
+
+use Laravel\Ai\Concerns\RemembersConversations;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\Conversational;
+use Laravel\Ai\Promptable;
+use Stringable;
+
+class WorkspaceGuide implements Agent, Conversational
+{
+    use Promptable, RemembersConversations;
+
+    /**
+     * Get the instructions that the agent should follow.
+     */
+    public function instructions(): Stringable|string
+    {
+        return <<<'PROMPT'
+You are Katra's workspace guide.
+
+Help shape durable, graph-native collaboration spaces. Favor concise guidance that keeps rooms, chats, agents, tasks, artifacts, and decisions connected without turning the product into a disposable chat transcript.
+PROMPT;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.4",
+        "laravel/ai": "^0.3.2",
         "laravel/framework": "^13.0",
         "laravel/pennant": "^1.0",
         "laravel/tinker": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "26afd95ae23fb3e697e5ef21234b7e87",
+    "content-hash": "a334e1d5bb8705de1ccf4e713cb2520e",
     "packages": [
         {
             "name": "blade-ui-kit/blade-icons",
@@ -1133,6 +1133,72 @@
                 }
             ],
             "time": "2025-08-22T14:27:06+00:00"
+        },
+        {
+            "name": "laravel/ai",
+            "version": "v0.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/ai.git",
+                "reference": "dfdf853427eb9fb8d763f8d9e2ed62cfcc03fb9c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/ai/zipball/dfdf853427eb9fb8d763f8d9e2ed62cfcc03fb9c",
+                "reference": "dfdf853427eb9fb8d763f8d9e2ed62cfcc03fb9c",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/console": "^12.0|^13.0",
+                "illuminate/container": "^12.0|^13.0",
+                "illuminate/contracts": "^12.0|^13.0",
+                "illuminate/filesystem": "^12.0|^13.0",
+                "illuminate/json-schema": "^12.0|^13.0",
+                "illuminate/support": "^12.0|^13.0",
+                "laravel/prompts": "^0.3.6",
+                "laravel/serializable-closure": "^2.0",
+                "php": "^8.3",
+                "prism-php/prism": "^0.99.0"
+            },
+            "require-dev": {
+                "laravel/pint": "^1.26",
+                "mockery/mockery": "^1.6.12",
+                "orchestra/testbench": "^10.6|^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Laravel\\Ai\\AiServiceProvider"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "functions.php"
+                ],
+                "psr-4": {
+                    "Laravel\\Ai\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "The official AI SDK for Laravel.",
+            "homepage": "https://github.com/laravel/ai",
+            "keywords": [
+                "ai",
+                "laravel"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/ai/issues",
+                "source": "https://github.com/laravel/ai"
+            },
+            "time": "2026-03-18T14:44:36+00:00"
         },
         {
             "name": "laravel/framework",
@@ -3029,6 +3095,85 @@
                 }
             ],
             "time": "2023-01-30T09:18:47+00:00"
+        },
+        {
+            "name": "prism-php/prism",
+            "version": "v0.99.22",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/prism-php/prism.git",
+                "reference": "989f67567aef69c613eae6e932d615fb96e2f5d7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/prism-php/prism/zipball/989f67567aef69c613eae6e932d615fb96e2f5d7",
+                "reference": "989f67567aef69c613eae6e932d615fb96e2f5d7",
+                "shasum": ""
+            },
+            "require": {
+                "ext-fileinfo": "*",
+                "laravel/framework": "^11.0|^12.0|^13.0",
+                "php": "^8.2"
+            },
+            "require-dev": {
+                "brianium/paratest": "^7.8.4",
+                "laravel/mcp": "^0.6.0",
+                "laravel/pint": "^1.14",
+                "mockery/mockery": "^1.6",
+                "orchestra/testbench": "^10",
+                "pestphp/pest": "^3.0",
+                "pestphp/pest-plugin-arch": "^3.0",
+                "pestphp/pest-plugin-laravel": "^3.0",
+                "phpstan/extension-installer": "^1.3",
+                "phpstan/phpdoc-parser": "^2.0",
+                "phpstan/phpstan": "2.1.34",
+                "phpstan/phpstan-deprecation-rules": "^2.0",
+                "projektgopher/whisky": "^0.7.0",
+                "rector/rector": "2.3.3",
+                "spatie/laravel-ray": "^1.39",
+                "symplify/rule-doc-generator-contracts": "^11.2"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "PrismServer": "Prism\\Prism\\Facades\\PrismServer"
+                    },
+                    "providers": [
+                        "Prism\\Prism\\PrismServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/helpers.php"
+                ],
+                "psr-4": {
+                    "Prism\\Prism\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "TJ Miller",
+                    "email": "hello@echolabs.dev"
+                }
+            ],
+            "description": "A powerful Laravel package for integrating Large Language Models (LLMs) into your applications.",
+            "support": {
+                "issues": "https://github.com/prism-php/prism/issues",
+                "source": "https://github.com/prism-php/prism/tree/v0.99.22"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sixlive",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-03-12T17:55:23+00:00"
         },
         {
             "name": "psr/clock",

--- a/config/ai.php
+++ b/config/ai.php
@@ -1,0 +1,129 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default AI Provider Names
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify which of the AI providers below should be the
+    | default for AI operations when no explicit provider is provided
+    | for the operation. This should be any provider defined below.
+    |
+    */
+
+    'default' => env('AI_DEFAULT_PROVIDER', 'openai'),
+    'default_for_images' => 'gemini',
+    'default_for_audio' => 'openai',
+    'default_for_transcription' => 'openai',
+    'default_for_embeddings' => 'openai',
+    'default_for_reranking' => 'cohere',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Caching
+    |--------------------------------------------------------------------------
+    |
+    | Below you may configure caching strategies for AI related operations
+    | such as embedding generation. You are free to adjust these values
+    | based on your application's available caching stores and needs.
+    |
+    */
+
+    'caching' => [
+        'embeddings' => [
+            'cache' => false,
+            'store' => env('CACHE_STORE', 'database'),
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | AI Providers
+    |--------------------------------------------------------------------------
+    |
+    | Below are each of your AI providers defined for this application. Each
+    | represents an AI provider and API key combination which can be used
+    | to perform tasks like text, image, and audio creation via agents.
+    |
+    */
+
+    'providers' => [
+        'anthropic' => [
+            'driver' => 'anthropic',
+            'key' => env('ANTHROPIC_API_KEY'),
+        ],
+
+        'azure' => [
+            'driver' => 'azure',
+            'key' => env('AZURE_OPENAI_API_KEY'),
+            'url' => env('AZURE_OPENAI_URL'),
+            'api_version' => env('AZURE_OPENAI_API_VERSION', '2024-10-21'),
+            'deployment' => env('AZURE_OPENAI_DEPLOYMENT', 'gpt-4o'),
+            'embedding_deployment' => env('AZURE_OPENAI_EMBEDDING_DEPLOYMENT', 'text-embedding-3-small'),
+        ],
+
+        'cohere' => [
+            'driver' => 'cohere',
+            'key' => env('COHERE_API_KEY'),
+        ],
+
+        'deepseek' => [
+            'driver' => 'deepseek',
+            'key' => env('DEEPSEEK_API_KEY'),
+        ],
+
+        'eleven' => [
+            'driver' => 'eleven',
+            'key' => env('ELEVENLABS_API_KEY'),
+        ],
+
+        'gemini' => [
+            'driver' => 'gemini',
+            'key' => env('GEMINI_API_KEY'),
+        ],
+
+        'groq' => [
+            'driver' => 'groq',
+            'key' => env('GROQ_API_KEY'),
+        ],
+
+        'jina' => [
+            'driver' => 'jina',
+            'key' => env('JINA_API_KEY'),
+        ],
+
+        'mistral' => [
+            'driver' => 'mistral',
+            'key' => env('MISTRAL_API_KEY'),
+        ],
+
+        'ollama' => [
+            'driver' => 'ollama',
+            'key' => env('OLLAMA_API_KEY', ''),
+            'url' => env('OLLAMA_BASE_URL', 'http://localhost:11434'),
+        ],
+
+        'openai' => [
+            'driver' => 'openai',
+            'key' => env('OPENAI_API_KEY'),
+        ],
+
+        'openrouter' => [
+            'driver' => 'openrouter',
+            'key' => env('OPENROUTER_API_KEY'),
+        ],
+
+        'voyageai' => [
+            'driver' => 'voyageai',
+            'key' => env('VOYAGEAI_API_KEY'),
+        ],
+
+        'xai' => [
+            'driver' => 'xai',
+            'key' => env('XAI_API_KEY'),
+        ],
+    ],
+
+];

--- a/database/migrations/2026_03_23_012737_create_agent_conversations_table.php
+++ b/database/migrations/2026_03_23_012737_create_agent_conversations_table.php
@@ -1,0 +1,50 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Laravel\Ai\Migrations\AiMigration;
+
+return new class extends AiMigration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('agent_conversations', function (Blueprint $table) {
+            $table->string('id', 36)->primary();
+            $table->foreignId('user_id')->nullable();
+            $table->string('title');
+            $table->timestamps();
+
+            $table->index(['user_id', 'updated_at']);
+        });
+
+        Schema::create('agent_conversation_messages', function (Blueprint $table) {
+            $table->string('id', 36)->primary();
+            $table->string('conversation_id', 36)->index();
+            $table->foreignId('user_id')->nullable();
+            $table->string('agent');
+            $table->string('role', 25);
+            $table->text('content');
+            $table->text('attachments');
+            $table->text('tool_calls');
+            $table->text('tool_results');
+            $table->text('usage');
+            $table->text('meta');
+            $table->timestamps();
+
+            $table->index(['conversation_id', 'user_id', 'updated_at'], 'conversation_index');
+            $table->index(['user_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('agent_conversations');
+        Schema::dropIfExists('agent_conversation_messages');
+    }
+};

--- a/database/migrations/2026_03_23_012737_create_agent_conversations_table.php
+++ b/database/migrations/2026_03_23_012737_create_agent_conversations_table.php
@@ -22,7 +22,7 @@ return new class extends AiMigration
 
         Schema::create('agent_conversation_messages', function (Blueprint $table) {
             $table->string('id', 36)->primary();
-            $table->string('conversation_id', 36)->index();
+            $table->string('conversation_id', 36);
             $table->foreignId('user_id')->nullable();
             $table->string('agent');
             $table->string('role', 25);
@@ -44,7 +44,7 @@ return new class extends AiMigration
      */
     public function down(): void
     {
-        Schema::dropIfExists('agent_conversations');
         Schema::dropIfExists('agent_conversation_messages');
+        Schema::dropIfExists('agent_conversations');
     }
 };

--- a/tests/Feature/LaravelAiAgentTest.php
+++ b/tests/Feature/LaravelAiAgentTest.php
@@ -50,6 +50,7 @@ test('workspace guide can fake and remember a conversation', function () {
     $messages = DB::table('agent_conversation_messages')
         ->where('conversation_id', $conversationId)
         ->orderBy('created_at')
+        ->orderBy('id')
         ->pluck('role')
         ->all();
 

--- a/tests/Feature/LaravelAiAgentTest.php
+++ b/tests/Feature/LaravelAiAgentTest.php
@@ -1,0 +1,64 @@
+<?php
+
+use App\Ai\Agents\WorkspaceGuide;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Laravel\Ai\Prompts\AgentPrompt;
+
+uses(RefreshDatabase::class);
+
+test('workspace guide can fake and remember a conversation', function () {
+    config()->set('ai.default', 'openai');
+    config()->set('ai.providers.openai.key', 'test-openai-key');
+
+    $user = User::factory()->create();
+
+    WorkspaceGuide::fake(function (string $prompt): string {
+        return str_contains($prompt, 'tasks, artifacts, and decisions')
+            ? 'Treat tasks, artifacts, and decisions as linked nodes instead of disposable transcript branches.'
+            : 'Start with one durable room per participant set and keep linked nodes in the context rail.';
+    })->preventStrayPrompts();
+
+    $agent = WorkspaceGuide::make()->forUser($user);
+
+    $openingResponse = $agent->prompt('How should Katra structure room context?');
+    $conversationId = $agent->currentConversation();
+
+    $followUpAgent = WorkspaceGuide::make()->continueLastConversation($user);
+    $followUpResponse = $followUpAgent->prompt('What should happen to tasks, artifacts, and decisions?');
+
+    expect($conversationId)->not->toBeNull()
+        ->and($openingResponse->conversationId)->toBe($conversationId)
+        ->and($followUpAgent->currentConversation())->toBe($conversationId)
+        ->and($followUpResponse->conversationId)->toBe($conversationId)
+        ->and($openingResponse->text)->toContain('durable room')
+        ->and($followUpResponse->text)->toContain('linked nodes');
+
+    WorkspaceGuide::assertPrompted(function (AgentPrompt $prompt): bool {
+        return $prompt->contains('room context');
+    });
+
+    WorkspaceGuide::assertPrompted(function (AgentPrompt $prompt): bool {
+        return $prompt->contains('tasks, artifacts, and decisions');
+    });
+
+    $this->assertDatabaseCount('agent_conversations', 1);
+    $this->assertDatabaseCount('agent_conversation_messages', 4);
+
+    $conversation = DB::table('agent_conversations')->first();
+    $messages = DB::table('agent_conversation_messages')
+        ->where('conversation_id', $conversationId)
+        ->orderBy('created_at')
+        ->pluck('role')
+        ->all();
+
+    expect((int) $conversation->user_id)->toBe($user->id)
+        ->and($conversation->title)->toContain('durable room')
+        ->and($messages)->toBe([
+            'user',
+            'assistant',
+            'user',
+            'assistant',
+        ]);
+});


### PR DESCRIPTION
## Summary
- install the official Laravel AI SDK and publish its config plus conversation storage migration
- add a small `WorkspaceGuide` agent that uses remembered conversations
- document the initial provider env setup and prove the integration with a fake-backed Pest test

## Testing
- vendor/bin/pint --dirty --format agent
- php artisan test --compact tests/Feature/LaravelAiAgentTest.php
- php artisan migrate --no-interaction

Closes #31