### PR TITLE
feat: add surreal schema driver foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,15 @@ The Laravel AI SDK is installed and its conversation storage migrations are part
 
 The current AI foundation test uses agent fakes, so the repo test suite does not require live provider credentials just to verify the integration.
 
+### Surreal-Backed Migrations
+
+Katra now includes a first Laravel-compatible Surreal schema driver for migration work.
+
+- Use `Schema::connection('surreal')` inside migrations when you want to target Surreal-backed application data.
+- You can also set `DB_CONNECTION=surreal` and run Laravel migrations, migration status, and `migrate:fresh` directly against SurrealDB.
+- The current slice is intentionally narrow: table creation, field creation, field removal, and table removal are supported for common Katra field types.
+- This is still not full SQL-driver parity yet, but it is enough for Katra's current migration set and for Surreal-backed application schema work without relying on SQLite migration bookkeeping.
+
 ## Planning Docs
 
 - [Katra v2 Overview](docs/v2-overview.md)

--- a/app/Console/Commands/SurrealProbeCommand.php
+++ b/app/Console/Commands/SurrealProbeCommand.php
@@ -3,6 +3,7 @@
 namespace App\Console\Commands;
 
 use App\Services\Surreal\SurrealCliClient;
+use App\Services\Surreal\SurrealHttpClient;
 use Illuminate\Console\Attributes\Description;
 use Illuminate\Console\Attributes\Signature;
 use Illuminate\Console\Command;
@@ -15,14 +16,15 @@ use RuntimeException;
 class SurrealProbeCommand extends Command
 {
     public function __construct(
-        private readonly SurrealCliClient $client,
+        private readonly SurrealCliClient $cliClient,
+        private readonly SurrealHttpClient $httpClient,
     ) {
         parent::__construct();
     }
 
     public function handle(): int
     {
-        if (! $this->client->isAvailable()) {
+        if (! $this->cliClient->isAvailable()) {
             $this->components->error('Unable to find the `surreal` CLI. Install it first or set SURREAL_BINARY to the executable path.');
 
             return self::FAILURE;
@@ -55,7 +57,7 @@ class SurrealProbeCommand extends Command
 
         File::ensureDirectoryExists(dirname($storagePath));
 
-        $server = $this->client->startLocalServer(
+        $server = $this->cliClient->startLocalServer(
             bindAddress: $bindAddress,
             datastorePath: $storagePath,
             username: $username,
@@ -64,11 +66,11 @@ class SurrealProbeCommand extends Command
         );
 
         try {
-            if (! $this->client->waitUntilReady($endpoint)) {
+            if (! $this->httpClient->waitUntilReady($endpoint)) {
                 throw new RuntimeException(sprintf('SurrealDB did not become ready on %s.', $endpoint));
             }
 
-            $results = $this->client->runQuery(
+            $results = $this->httpClient->runQuery(
                 endpoint: $endpoint,
                 namespace: $namespace,
                 database: $database,

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -6,6 +6,7 @@ use App\Services\Surreal\Migrations\SurrealMigrationRepository;
 use App\Services\Surreal\Schema\SurrealSchemaConnection;
 use App\Services\Surreal\SurrealConnection;
 use App\Services\Surreal\SurrealDocumentStore;
+use App\Services\Surreal\SurrealHttpClient;
 use App\Services\Surreal\SurrealRuntimeManager;
 use Illuminate\Database\DatabaseManager;
 use Illuminate\Support\ServiceProvider;
@@ -15,6 +16,7 @@ class AppServiceProvider extends ServiceProvider
     public function register(): void
     {
         $this->app->singleton(SurrealConnection::class, fn (): SurrealConnection => SurrealConnection::fromConfig(config('surreal')));
+        $this->app->singleton(SurrealHttpClient::class);
         $this->app->singleton(SurrealRuntimeManager::class);
         $this->app->singleton(SurrealDocumentStore::class);
     }
@@ -25,7 +27,7 @@ class AppServiceProvider extends ServiceProvider
             $migrations = $app['config']['database.migrations'];
             $table = is_array($migrations) ? ($migrations['table'] ?? 'migrations') : $migrations;
 
-            return new SurrealMigrationRepository($app['db'], $table);
+            return new SurrealMigrationRepository($app['db'], $table, $app->make(SurrealHttpClient::class));
         });
 
         $this->app->make(DatabaseManager::class)->extend('surreal', function (array $config, string $name): SurrealSchemaConnection {

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,9 +2,12 @@
 
 namespace App\Providers;
 
+use App\Services\Surreal\Migrations\SurrealMigrationRepository;
+use App\Services\Surreal\Schema\SurrealSchemaConnection;
 use App\Services\Surreal\SurrealConnection;
 use App\Services\Surreal\SurrealDocumentStore;
 use App\Services\Surreal\SurrealRuntimeManager;
+use Illuminate\Database\DatabaseManager;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -18,6 +21,18 @@ class AppServiceProvider extends ServiceProvider
 
     public function boot(): void
     {
-        //
+        $this->app->extend('migration.repository', function ($repository, $app): SurrealMigrationRepository {
+            $migrations = $app['config']['database.migrations'];
+            $table = is_array($migrations) ? ($migrations['table'] ?? 'migrations') : $migrations;
+
+            return new SurrealMigrationRepository($app['db'], $table);
+        });
+
+        $this->app->make(DatabaseManager::class)->extend('surreal', function (array $config, string $name): SurrealSchemaConnection {
+            return SurrealSchemaConnection::fromConfig(
+                array_merge(config('surreal'), $config),
+                $name,
+            );
+        });
     }
 }

--- a/app/Services/Surreal/Migrations/SurrealMigrationRepository.php
+++ b/app/Services/Surreal/Migrations/SurrealMigrationRepository.php
@@ -158,7 +158,7 @@ class SurrealMigrationRepository extends DatabaseMigrationRepository
             return parent::repositoryExists();
         }
 
-        return $this->schemaManager()->hasTable($this->table);
+        return $this->schemaManager()->hasTable($this->normalizedTable());
     }
 
     public function deleteRepository()

--- a/app/Services/Surreal/Migrations/SurrealMigrationRepository.php
+++ b/app/Services/Surreal/Migrations/SurrealMigrationRepository.php
@@ -5,6 +5,7 @@ namespace App\Services\Surreal\Migrations;
 use App\Services\Surreal\Schema\SurrealSchemaConnection;
 use App\Services\Surreal\Schema\SurrealSchemaManager;
 use App\Services\Surreal\SurrealHttpClient;
+use App\Services\Surreal\SurrealRuntimeManager;
 use Illuminate\Database\ConnectionResolverInterface as Resolver;
 use Illuminate\Database\Migrations\DatabaseMigrationRepository;
 use Illuminate\Support\Arr;
@@ -221,6 +222,10 @@ class SurrealMigrationRepository extends DatabaseMigrationRepository
      */
     private function query(string $query): array
     {
+        if (! $this->runtimeManager()->ensureReady()) {
+            throw new \RuntimeException('The SurrealDB runtime is not available for migration repository operations.');
+        }
+
         return $this->client->runQuery(
             endpoint: (string) $this->surrealConfig('endpoint'),
             namespace: (string) $this->surrealConfig('namespace'),
@@ -237,6 +242,14 @@ class SurrealMigrationRepository extends DatabaseMigrationRepository
         $connection = $this->resolver->connection($this->connection ?? $this->resolver->getDefaultConnection());
 
         return $connection->schemaManager();
+    }
+
+    private function runtimeManager(): SurrealRuntimeManager
+    {
+        /** @var SurrealSchemaConnection $connection */
+        $connection = $this->resolver->connection($this->connection ?? $this->resolver->getDefaultConnection());
+
+        return $connection->runtimeManager();
     }
 
     private function surrealConfig(string $key): mixed

--- a/app/Services/Surreal/Migrations/SurrealMigrationRepository.php
+++ b/app/Services/Surreal/Migrations/SurrealMigrationRepository.php
@@ -1,0 +1,280 @@
+<?php
+
+namespace App\Services\Surreal\Migrations;
+
+use App\Services\Surreal\Schema\SurrealSchemaConnection;
+use App\Services\Surreal\Schema\SurrealSchemaManager;
+use App\Services\Surreal\SurrealCliClient;
+use Illuminate\Database\ConnectionResolverInterface as Resolver;
+use Illuminate\Database\Migrations\DatabaseMigrationRepository;
+use Illuminate\Support\Arr;
+use JsonException;
+
+class SurrealMigrationRepository extends DatabaseMigrationRepository
+{
+    public function __construct(Resolver $resolver, string $table)
+    {
+        parent::__construct($resolver, $table);
+    }
+
+    public function getRan()
+    {
+        if (! $this->usesSurrealRepository()) {
+            return parent::getRan();
+        }
+
+        return array_map(
+            static fn (array $row): string => (string) $row['migration'],
+            $this->selectRows(sprintf(
+                'SELECT migration, batch FROM %s ORDER BY batch ASC, migration ASC;',
+                $this->normalizedTable(),
+            )),
+        );
+    }
+
+    public function getMigrations($steps)
+    {
+        if (! $this->usesSurrealRepository()) {
+            return parent::getMigrations($steps);
+        }
+
+        return $this->selectRows(sprintf(
+            'SELECT migration, batch FROM %s WHERE batch >= 1 ORDER BY batch DESC, migration DESC LIMIT %d;',
+            $this->normalizedTable(),
+            (int) $steps,
+        ));
+    }
+
+    public function getMigrationsByBatch($batch)
+    {
+        if (! $this->usesSurrealRepository()) {
+            return parent::getMigrationsByBatch($batch);
+        }
+
+        return $this->selectRows(sprintf(
+            'SELECT migration, batch FROM %s WHERE batch = %d ORDER BY migration DESC;',
+            $this->normalizedTable(),
+            (int) $batch,
+        ));
+    }
+
+    public function getLast()
+    {
+        if (! $this->usesSurrealRepository()) {
+            return parent::getLast();
+        }
+
+        $lastBatch = $this->getLastBatchNumber();
+
+        if ($lastBatch === 0) {
+            return [];
+        }
+
+        return $this->getMigrationsByBatch($lastBatch);
+    }
+
+    public function getMigrationBatches()
+    {
+        if (! $this->usesSurrealRepository()) {
+            return parent::getMigrationBatches();
+        }
+
+        $batches = [];
+
+        foreach ($this->selectRows(sprintf(
+            'SELECT migration, batch FROM %s ORDER BY batch ASC, migration ASC;',
+            $this->normalizedTable(),
+        )) as $row) {
+            $batches[(string) $row['migration']] = (int) $row['batch'];
+        }
+
+        return $batches;
+    }
+
+    public function log($file, $batch)
+    {
+        if (! $this->usesSurrealRepository()) {
+            parent::log($file, $batch);
+
+            return;
+        }
+
+        $this->schemaManager()->statement(sprintf(
+            'CREATE %s CONTENT %s;',
+            $this->normalizedTable(),
+            $this->jsonLiteral([
+                'migration' => (string) $file,
+                'batch' => (int) $batch,
+            ]),
+        ));
+    }
+
+    public function delete($migration)
+    {
+        if (! $this->usesSurrealRepository()) {
+            parent::delete($migration);
+
+            return;
+        }
+
+        $this->schemaManager()->statement(sprintf(
+            'DELETE %s WHERE migration = %s;',
+            $this->normalizedTable(),
+            $this->jsonLiteral((string) $migration->migration),
+        ));
+    }
+
+    public function getLastBatchNumber()
+    {
+        if (! $this->usesSurrealRepository()) {
+            return parent::getLastBatchNumber();
+        }
+
+        return (int) $this->selectScalar(sprintf(
+            'SELECT VALUE batch FROM %s ORDER BY batch DESC LIMIT 1;',
+            $this->normalizedTable(),
+        ), 0);
+    }
+
+    public function createRepository()
+    {
+        if (! $this->usesSurrealRepository()) {
+            parent::createRepository();
+
+            return;
+        }
+
+        $this->schemaManager()->statements([
+            sprintf('DEFINE TABLE %s SCHEMAFULL;', $this->normalizedTable()),
+            sprintf('DEFINE FIELD migration ON TABLE %s TYPE string;', $this->normalizedTable()),
+            sprintf('DEFINE FIELD batch ON TABLE %s TYPE int;', $this->normalizedTable()),
+            sprintf('DEFINE INDEX migration_unique ON TABLE %s COLUMNS migration UNIQUE;', $this->normalizedTable()),
+        ]);
+    }
+
+    public function repositoryExists()
+    {
+        if (! $this->usesSurrealRepository()) {
+            return parent::repositoryExists();
+        }
+
+        return $this->schemaManager()->hasTable($this->table);
+    }
+
+    public function deleteRepository()
+    {
+        if (! $this->usesSurrealRepository()) {
+            parent::deleteRepository();
+
+            return;
+        }
+
+        $this->schemaManager()->statement(sprintf('REMOVE TABLE %s;', $this->normalizedTable()));
+    }
+
+    private function usesSurrealRepository(): bool
+    {
+        $connectionName = $this->connection ?? $this->resolver->getDefaultConnection();
+
+        if ($connectionName === null) {
+            return false;
+        }
+
+        return $this->connectionDriver($connectionName) === 'surreal';
+    }
+
+    private function connectionDriver(string $connectionName): ?string
+    {
+        return $this->resolver->connection($connectionName)->getConfig('driver');
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function selectRows(string $query): array
+    {
+        $result = Arr::get($this->query($query), '0.0', []);
+
+        if (! is_array($result)) {
+            return [];
+        }
+
+        return array_values(array_filter(
+            $result,
+            static fn (mixed $row): bool => is_array($row),
+        ));
+    }
+
+    private function selectScalar(string $query, mixed $default = null): mixed
+    {
+        $result = Arr::get($this->query($query), '0.0', []);
+
+        if (! is_array($result) || $result === []) {
+            return $default;
+        }
+
+        return $result[0] ?? $default;
+    }
+
+    /**
+     * @return list<mixed>
+     */
+    private function query(string $query): array
+    {
+        return $this->surrealClient()->runQuery(
+            endpoint: (string) $this->surrealConfig('endpoint'),
+            namespace: (string) $this->surrealConfig('namespace'),
+            database: (string) $this->surrealConfig('database'),
+            username: (string) $this->surrealConfig('username'),
+            password: (string) $this->surrealConfig('password'),
+            query: $query,
+        );
+    }
+
+    private function schemaManager(): SurrealSchemaManager
+    {
+        /** @var SurrealSchemaConnection $connection */
+        $connection = $this->resolver->connection($this->connection ?? $this->resolver->getDefaultConnection());
+
+        return $connection->schemaManager();
+    }
+
+    private function surrealClient(): SurrealCliClient
+    {
+        return new SurrealCliClient(
+            configuredBinary: $this->stringConfig('binary'),
+            extrasPath: $this->stringConfig('extras_path'),
+            bundledBinaryRelativePath: $this->stringConfig('bundled_binary_relative_path'),
+        );
+    }
+
+    private function surrealConfig(string $key): mixed
+    {
+        return $this->resolver->connection($this->connection ?? $this->resolver->getDefaultConnection())->getConfig($key);
+    }
+
+    private function stringConfig(string $key): ?string
+    {
+        $value = $this->surrealConfig($key);
+
+        return is_string($value) && $value !== '' ? $value : null;
+    }
+
+    private function normalizedTable(): string
+    {
+        if (! preg_match('/^[A-Za-z0-9_]+$/', $this->table)) {
+            throw new \RuntimeException(sprintf('The Surreal migration table identifier [%s] contains unsupported characters.', $this->table));
+        }
+
+        return $this->table;
+    }
+
+    private function jsonLiteral(mixed $value): string
+    {
+        try {
+            return json_encode($value, JSON_THROW_ON_ERROR);
+        } catch (JsonException $exception) {
+            throw new \RuntimeException('Unable to encode the Surreal migration payload.', previous: $exception);
+        }
+    }
+}

--- a/app/Services/Surreal/Migrations/SurrealMigrationRepository.php
+++ b/app/Services/Surreal/Migrations/SurrealMigrationRepository.php
@@ -4,7 +4,7 @@ namespace App\Services\Surreal\Migrations;
 
 use App\Services\Surreal\Schema\SurrealSchemaConnection;
 use App\Services\Surreal\Schema\SurrealSchemaManager;
-use App\Services\Surreal\SurrealCliClient;
+use App\Services\Surreal\SurrealHttpClient;
 use Illuminate\Database\ConnectionResolverInterface as Resolver;
 use Illuminate\Database\Migrations\DatabaseMigrationRepository;
 use Illuminate\Support\Arr;
@@ -12,7 +12,7 @@ use JsonException;
 
 class SurrealMigrationRepository extends DatabaseMigrationRepository
 {
-    public function __construct(Resolver $resolver, string $table)
+    public function __construct(Resolver $resolver, string $table, private readonly SurrealHttpClient $client)
     {
         parent::__construct($resolver, $table);
     }
@@ -193,7 +193,7 @@ class SurrealMigrationRepository extends DatabaseMigrationRepository
      */
     private function selectRows(string $query): array
     {
-        $result = Arr::get($this->query($query), '0.0', []);
+        $result = Arr::get($this->query($query), '0', []);
 
         if (! is_array($result)) {
             return [];
@@ -207,7 +207,7 @@ class SurrealMigrationRepository extends DatabaseMigrationRepository
 
     private function selectScalar(string $query, mixed $default = null): mixed
     {
-        $result = Arr::get($this->query($query), '0.0', []);
+        $result = Arr::get($this->query($query), '0', []);
 
         if (! is_array($result) || $result === []) {
             return $default;
@@ -221,7 +221,7 @@ class SurrealMigrationRepository extends DatabaseMigrationRepository
      */
     private function query(string $query): array
     {
-        return $this->surrealClient()->runQuery(
+        return $this->client->runQuery(
             endpoint: (string) $this->surrealConfig('endpoint'),
             namespace: (string) $this->surrealConfig('namespace'),
             database: (string) $this->surrealConfig('database'),
@@ -239,25 +239,9 @@ class SurrealMigrationRepository extends DatabaseMigrationRepository
         return $connection->schemaManager();
     }
 
-    private function surrealClient(): SurrealCliClient
-    {
-        return new SurrealCliClient(
-            configuredBinary: $this->stringConfig('binary'),
-            extrasPath: $this->stringConfig('extras_path'),
-            bundledBinaryRelativePath: $this->stringConfig('bundled_binary_relative_path'),
-        );
-    }
-
     private function surrealConfig(string $key): mixed
     {
         return $this->resolver->connection($this->connection ?? $this->resolver->getDefaultConnection())->getConfig($key);
-    }
-
-    private function stringConfig(string $key): ?string
-    {
-        $value = $this->surrealConfig($key);
-
-        return is_string($value) && $value !== '' ? $value : null;
     }
 
     private function normalizedTable(): string

--- a/app/Services/Surreal/Schema/SurrealSchemaBuilder.php
+++ b/app/Services/Surreal/Schema/SurrealSchemaBuilder.php
@@ -3,8 +3,8 @@
 namespace App\Services\Surreal\Schema;
 
 use Illuminate\Database\Connection;
-use Illuminate\Database\Schema\Builder;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Schema\Builder;
 
 class SurrealSchemaBuilder extends Builder
 {

--- a/app/Services/Surreal/Schema/SurrealSchemaBuilder.php
+++ b/app/Services/Surreal/Schema/SurrealSchemaBuilder.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Services\Surreal\Schema;
+
+use Illuminate\Database\Connection;
+use Illuminate\Database\Schema\Builder;
+use Illuminate\Database\Schema\Blueprint;
+
+class SurrealSchemaBuilder extends Builder
+{
+    public function __construct(
+        Connection $connection,
+        private readonly SurrealSchemaManager $manager,
+    ) {
+        parent::__construct($connection);
+    }
+
+    /**
+     * @return list<array{name: string, schema: string|null, schema_qualified_name: string, size: int|null, comment: string|null, collation: string|null, engine: string|null}>
+     */
+    public function getTables($schema = null): array
+    {
+        return $this->manager->tables();
+    }
+
+    public function hasTable($table): bool
+    {
+        [, $table] = $this->parseSchemaAndTable($table);
+
+        return $this->manager->hasTable($this->connection->getTablePrefix().$table);
+    }
+
+    /**
+     * @return list<array{name: string, type: string, type_name: string, nullable: bool, default: mixed, auto_increment: bool, comment: string|null, generation: array{type: string, expression: string|null}|null}>
+     */
+    public function getColumns($table): array
+    {
+        [, $table] = $this->parseSchemaAndTable($table);
+
+        return $this->manager->columns($this->connection->getTablePrefix().$table);
+    }
+
+    public function dropIfExists($table): void
+    {
+        if ($this->hasTable($table)) {
+            $this->drop($table);
+        }
+    }
+
+    public function dropAllTables(): void
+    {
+        $this->manager->dropAllTables();
+    }
+
+    protected function build(Blueprint $blueprint): void
+    {
+        $this->manager->statements(array_map(
+            static fn (mixed $statement): string => (string) $statement,
+            $blueprint->toSql(),
+        ));
+    }
+}

--- a/app/Services/Surreal/Schema/SurrealSchemaConnection.php
+++ b/app/Services/Surreal/Schema/SurrealSchemaConnection.php
@@ -10,7 +10,6 @@ use Closure;
 use Generator;
 use Illuminate\Database\Connection;
 use Illuminate\Http\Client\Factory;
-use PDO;
 use RuntimeException;
 
 class SurrealSchemaConnection extends Connection
@@ -20,12 +19,15 @@ class SurrealSchemaConnection extends Connection
     public function __construct(
         array $config,
         private readonly SurrealSchemaManager $manager,
+        private readonly SurrealRuntimeManager $runtimeManager,
         string $name,
     ) {
         $config['name'] = $name;
 
         parent::__construct(
-            new PDO('sqlite::memory:'),
+            function (): never {
+                throw new RuntimeException('SurrealSchemaConnection does not expose a PDO driver. Use the Surreal schema/document layers instead.');
+            },
             $config['database'] ?? '',
             $config['prefix'] ?? '',
             $config,
@@ -41,14 +43,16 @@ class SurrealSchemaConnection extends Connection
             bundledBinaryRelativePath: isset($config['bundled_binary_relative_path']) ? (string) $config['bundled_binary_relative_path'] : null,
         );
         $httpClient = new SurrealHttpClient(app(Factory::class));
+        $runtimeManager = new SurrealRuntimeManager($client, $httpClient, $surrealConnection);
 
         return tap(new self(
             $config,
             new SurrealSchemaManager(
                 $httpClient,
                 $surrealConnection,
-                new SurrealRuntimeManager($client, $httpClient, $surrealConnection),
+                $runtimeManager,
             ),
+            $runtimeManager,
             $name,
         ), function (self $connection): void {
             $connection->useDefaultSchemaGrammar();
@@ -127,6 +131,11 @@ class SurrealSchemaConnection extends Connection
     public function schemaManager(): SurrealSchemaManager
     {
         return $this->manager;
+    }
+
+    public function runtimeManager(): SurrealRuntimeManager
+    {
+        return $this->runtimeManager;
     }
 
     protected function getDefaultSchemaGrammar(): SurrealSchemaGrammar

--- a/app/Services/Surreal/Schema/SurrealSchemaConnection.php
+++ b/app/Services/Surreal/Schema/SurrealSchemaConnection.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace App\Services\Surreal\Schema;
+
+use App\Services\Surreal\SurrealCliClient;
+use App\Services\Surreal\SurrealConnection;
+use App\Services\Surreal\SurrealRuntimeManager;
+use Illuminate\Database\Connection;
+use PDO;
+
+class SurrealSchemaConnection extends Connection
+{
+    private ?SurrealSchemaBuilder $schemaBuilder = null;
+
+    public function __construct(
+        array $config,
+        private readonly SurrealSchemaManager $manager,
+        string $name,
+    ) {
+        $config['name'] = $name;
+
+        parent::__construct(
+            new PDO('sqlite::memory:'),
+            $config['database'] ?? '',
+            $config['prefix'] ?? '',
+            $config,
+        );
+    }
+
+    public static function fromConfig(array $config, string $name): self
+    {
+        $surrealConnection = SurrealConnection::fromConfig($config);
+        $client = new SurrealCliClient(
+            configuredBinary: isset($config['binary']) ? (string) $config['binary'] : null,
+            extrasPath: isset($config['extras_path']) ? (string) $config['extras_path'] : null,
+            bundledBinaryRelativePath: isset($config['bundled_binary_relative_path']) ? (string) $config['bundled_binary_relative_path'] : null,
+        );
+
+        return tap(new self(
+            $config,
+            new SurrealSchemaManager(
+                $client,
+                $surrealConnection,
+                new SurrealRuntimeManager($client, $surrealConnection),
+            ),
+            $name,
+        ), function (self $connection): void {
+            $connection->useDefaultSchemaGrammar();
+        });
+    }
+
+    public function statement($query, $bindings = []): bool
+    {
+        return $this->manager->statement((string) $query);
+    }
+
+    public function unprepared($query): bool
+    {
+        return $this->statement((string) $query);
+    }
+
+    public function getSchemaBuilder(): SurrealSchemaBuilder
+    {
+        if ($this->schemaGrammar === null) {
+            $this->useDefaultSchemaGrammar();
+        }
+
+        return $this->schemaBuilder ??= new SurrealSchemaBuilder($this, $this->manager);
+    }
+
+    public function schemaManager(): SurrealSchemaManager
+    {
+        return $this->manager;
+    }
+
+    protected function getDefaultSchemaGrammar(): SurrealSchemaGrammar
+    {
+        return new SurrealSchemaGrammar($this);
+    }
+}

--- a/app/Services/Surreal/Schema/SurrealSchemaConnection.php
+++ b/app/Services/Surreal/Schema/SurrealSchemaConnection.php
@@ -6,9 +6,12 @@ use App\Services\Surreal\SurrealCliClient;
 use App\Services\Surreal\SurrealConnection;
 use App\Services\Surreal\SurrealHttpClient;
 use App\Services\Surreal\SurrealRuntimeManager;
+use Closure;
+use Generator;
 use Illuminate\Database\Connection;
 use Illuminate\Http\Client\Factory;
 use PDO;
+use RuntimeException;
 
 class SurrealSchemaConnection extends Connection
 {
@@ -57,6 +60,56 @@ class SurrealSchemaConnection extends Connection
         return $this->manager->statement((string) $query);
     }
 
+    public function getDriverName(): string
+    {
+        return 'surreal';
+    }
+
+    public function select($query, $bindings = [], $useReadPdo = true, array $fetchUsing = []): array
+    {
+        throw $this->unsupportedOperation('select queries');
+    }
+
+    public function cursor($query, $bindings = [], $useReadPdo = true, array $fetchUsing = []): Generator
+    {
+        throw $this->unsupportedOperation('cursors');
+    }
+
+    public function insert($query, $bindings = []): bool
+    {
+        throw $this->unsupportedOperation('insert queries');
+    }
+
+    public function update($query, $bindings = []): int
+    {
+        throw $this->unsupportedOperation('update queries');
+    }
+
+    public function delete($query, $bindings = []): int
+    {
+        throw $this->unsupportedOperation('delete queries');
+    }
+
+    public function transaction(Closure $callback, $attempts = 1): mixed
+    {
+        throw $this->unsupportedOperation('transactions');
+    }
+
+    public function beginTransaction(): void
+    {
+        throw $this->unsupportedOperation('transactions');
+    }
+
+    public function commit(): void
+    {
+        throw $this->unsupportedOperation('transactions');
+    }
+
+    public function rollBack($toLevel = null): void
+    {
+        throw $this->unsupportedOperation('transactions');
+    }
+
     public function unprepared($query): bool
     {
         return $this->statement((string) $query);
@@ -79,5 +132,13 @@ class SurrealSchemaConnection extends Connection
     protected function getDefaultSchemaGrammar(): SurrealSchemaGrammar
     {
         return new SurrealSchemaGrammar($this);
+    }
+
+    private function unsupportedOperation(string $operation): RuntimeException
+    {
+        return new RuntimeException(sprintf(
+            'SurrealSchemaConnection does not support %s. Use the Surreal document layer for data access.',
+            $operation,
+        ));
     }
 }

--- a/app/Services/Surreal/Schema/SurrealSchemaConnection.php
+++ b/app/Services/Surreal/Schema/SurrealSchemaConnection.php
@@ -4,8 +4,10 @@ namespace App\Services\Surreal\Schema;
 
 use App\Services\Surreal\SurrealCliClient;
 use App\Services\Surreal\SurrealConnection;
+use App\Services\Surreal\SurrealHttpClient;
 use App\Services\Surreal\SurrealRuntimeManager;
 use Illuminate\Database\Connection;
+use Illuminate\Http\Client\Factory;
 use PDO;
 
 class SurrealSchemaConnection extends Connection
@@ -35,13 +37,14 @@ class SurrealSchemaConnection extends Connection
             extrasPath: isset($config['extras_path']) ? (string) $config['extras_path'] : null,
             bundledBinaryRelativePath: isset($config['bundled_binary_relative_path']) ? (string) $config['bundled_binary_relative_path'] : null,
         );
+        $httpClient = new SurrealHttpClient(app(Factory::class));
 
         return tap(new self(
             $config,
             new SurrealSchemaManager(
-                $client,
+                $httpClient,
                 $surrealConnection,
-                new SurrealRuntimeManager($client, $surrealConnection),
+                new SurrealRuntimeManager($client, $httpClient, $surrealConnection),
             ),
             $name,
         ), function (self $connection): void {

--- a/app/Services/Surreal/Schema/SurrealSchemaGrammar.php
+++ b/app/Services/Surreal/Schema/SurrealSchemaGrammar.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace App\Services\Surreal\Schema;
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Schema\ColumnDefinition;
+use Illuminate\Database\Schema\Grammars\Grammar;
+use Illuminate\Support\Fluent;
+use RuntimeException;
+
+class SurrealSchemaGrammar extends Grammar
+{
+    /**
+     * @return list<string>
+     */
+    public function compileCreate(Blueprint $blueprint, Fluent $command): array
+    {
+        $table = $this->normalizeIdentifier($blueprint->getTable());
+
+        return array_merge(
+            [sprintf('DEFINE TABLE %s SCHEMAFULL;', $table)],
+            array_map(
+                fn (ColumnDefinition $column): string => $this->compileFieldDefinition($table, $column),
+                $blueprint->getColumns(),
+            ),
+        );
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function compileAdd(Blueprint $blueprint, Fluent $command): array
+    {
+        $table = $this->normalizeIdentifier($blueprint->getTable());
+
+        return [
+            $this->compileFieldDefinition($table, $command->column),
+        ];
+    }
+
+    public function compileDrop(Blueprint $blueprint, Fluent $command): string
+    {
+        return sprintf('REMOVE TABLE %s;', $this->normalizeIdentifier($blueprint->getTable()));
+    }
+
+    public function compileDropIfExists(Blueprint $blueprint, Fluent $command): string
+    {
+        return $this->compileDrop($blueprint, $command);
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function compileDropColumn(Blueprint $blueprint, Fluent $command): array
+    {
+        $table = $this->normalizeIdentifier($blueprint->getTable());
+
+        return array_map(
+            fn (string $column): string => sprintf(
+                'REMOVE FIELD %s ON TABLE %s;',
+                $this->normalizeIdentifier($column),
+                $table,
+            ),
+            $command->columns,
+        );
+    }
+
+    public function compileRenameColumn(Blueprint $blueprint, Fluent $command): never
+    {
+        throw new RuntimeException('The current SurrealDB schema driver does not support renaming columns yet.');
+    }
+
+    public function compileForeign(Blueprint $blueprint, Fluent $command): never
+    {
+        throw new RuntimeException('The current SurrealDB schema driver does not support foreign key constraints.');
+    }
+
+    private function compileFieldDefinition(string $table, ColumnDefinition $column): string
+    {
+        return sprintf(
+            'DEFINE FIELD %s ON TABLE %s TYPE %s;',
+            $this->normalizeIdentifier($column->name),
+            $table,
+            $this->surrealTypeFor($column),
+        );
+    }
+
+    private function surrealTypeFor(ColumnDefinition $column): string
+    {
+        $baseType = match ($column->type) {
+            'bigIncrements', 'bigInteger', 'foreignId', 'unsignedBigInteger' => 'int',
+            'increments', 'integer', 'mediumIncrements', 'mediumInteger', 'unsignedInteger' => 'int',
+            'smallIncrements', 'smallInteger', 'unsignedSmallInteger' => 'int',
+            'tinyIncrements', 'tinyInteger', 'unsignedTinyInteger' => 'int',
+            'char', 'string', 'tinyText', 'text', 'mediumText', 'longText', 'ulid' => 'string',
+            'float', 'double', 'decimal' => 'number',
+            'boolean' => 'bool',
+            'json', 'jsonb' => 'any',
+            'date', 'dateTime', 'dateTimeTz', 'time', 'timeTz', 'timestamp', 'timestampTz' => 'datetime',
+            'uuid' => 'uuid',
+            default => throw new RuntimeException(sprintf('The current SurrealDB schema driver does not support the [%s] column type yet.', $column->type)),
+        };
+
+        return $column->nullable ? sprintf('none | %s', $baseType) : $baseType;
+    }
+
+    private function normalizeIdentifier(string $identifier): string
+    {
+        if (! preg_match('/^[A-Za-z0-9_]+$/', $identifier)) {
+            throw new RuntimeException(sprintf('The Surreal schema identifier [%s] contains unsupported characters.', $identifier));
+        }
+
+        return $identifier;
+    }
+}

--- a/app/Services/Surreal/Schema/SurrealSchemaManager.php
+++ b/app/Services/Surreal/Schema/SurrealSchemaManager.php
@@ -2,8 +2,8 @@
 
 namespace App\Services\Surreal\Schema;
 
-use App\Services\Surreal\SurrealCliClient;
 use App\Services\Surreal\SurrealConnection;
+use App\Services\Surreal\SurrealHttpClient;
 use App\Services\Surreal\SurrealRuntimeManager;
 use Illuminate\Support\Arr;
 use RuntimeException;
@@ -11,7 +11,7 @@ use RuntimeException;
 class SurrealSchemaManager
 {
     public function __construct(
-        private readonly SurrealCliClient $client,
+        private readonly SurrealHttpClient $client,
         private readonly SurrealConnection $connection,
         private readonly SurrealRuntimeManager $runtimeManager,
     ) {}

--- a/app/Services/Surreal/Schema/SurrealSchemaManager.php
+++ b/app/Services/Surreal/Schema/SurrealSchemaManager.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace App\Services\Surreal\Schema;
+
+use App\Services\Surreal\SurrealCliClient;
+use App\Services\Surreal\SurrealConnection;
+use App\Services\Surreal\SurrealRuntimeManager;
+use Illuminate\Support\Arr;
+use RuntimeException;
+
+class SurrealSchemaManager
+{
+    public function __construct(
+        private readonly SurrealCliClient $client,
+        private readonly SurrealConnection $connection,
+        private readonly SurrealRuntimeManager $runtimeManager,
+    ) {}
+
+    public function statement(string $statement): bool
+    {
+        $this->run($statement);
+
+        return true;
+    }
+
+    /**
+     * @param  list<string>  $statements
+     */
+    public function statements(array $statements): bool
+    {
+        $statements = array_values(array_filter(array_map(
+            static fn (string $statement): string => trim($statement),
+            $statements,
+        )));
+
+        if ($statements === []) {
+            return true;
+        }
+
+        $this->run(implode("\n", $statements));
+
+        return true;
+    }
+
+    /**
+     * @return list<array{name: string, schema: string|null, schema_qualified_name: string, size: int|null, comment: string|null, collation: string|null, engine: string|null}>
+     */
+    public function tables(): array
+    {
+        $tables = Arr::get($this->run('INFO FOR DB;'), '0.0.tables', []);
+
+        if (! is_array($tables)) {
+            return [];
+        }
+
+        return array_values(array_map(
+            static fn (string $definition, string $name): array => [
+                'name' => $name,
+                'schema' => null,
+                'schema_qualified_name' => $name,
+                'size' => null,
+                'comment' => $definition,
+                'collation' => null,
+                'engine' => null,
+            ],
+            $tables,
+            array_keys($tables),
+        ));
+    }
+
+    public function hasTable(string $table): bool
+    {
+        return collect($this->tables())->contains(
+            static fn (array $definition): bool => $definition['name'] === $table
+        );
+    }
+
+    /**
+     * @return list<array{name: string, type: string, type_name: string, nullable: bool, default: mixed, auto_increment: bool, comment: string|null, generation: array{type: string, expression: string|null}|null}>
+     */
+    public function columns(string $table): array
+    {
+        $fields = Arr::get($this->run(sprintf('INFO FOR TABLE %s;', $this->normalizeIdentifier($table))), '0.0.fields', []);
+
+        if (! is_array($fields)) {
+            return [];
+        }
+
+        return array_values(array_map(
+            fn (string $definition, string $name): array => $this->normalizeFieldDefinition($name, $definition),
+            $fields,
+            array_keys($fields),
+        ));
+    }
+
+    public function dropAllTables(): void
+    {
+        $this->statements(array_map(
+            fn (array $table): string => sprintf('REMOVE TABLE %s;', $this->normalizeIdentifier($table['name'])),
+            $this->tables(),
+        ));
+    }
+
+    /**
+     * @return list<mixed>
+     */
+    private function run(string $query): array
+    {
+        if (! $this->runtimeManager->ensureReady()) {
+            throw new RuntimeException('The SurrealDB runtime is not available for schema operations.');
+        }
+
+        return $this->client->runQuery(
+            endpoint: $this->connection->endpoint,
+            namespace: $this->connection->namespace,
+            database: $this->connection->database,
+            username: $this->connection->username,
+            password: $this->connection->password,
+            query: $query,
+        );
+    }
+
+    /**
+     * @return array{name: string, type: string, type_name: string, nullable: bool, default: mixed, auto_increment: bool, comment: string|null, generation: array{type: string, expression: string|null}|null}
+     */
+    private function normalizeFieldDefinition(string $name, string $definition): array
+    {
+        preg_match('/TYPE\s+(.+?)\s+PERMISSIONS/i', $definition, $matches);
+
+        $typeDefinition = $matches[1] ?? 'any';
+        $nullable = str_contains($typeDefinition, 'none | ');
+        $typeName = trim(str_replace('none |', '', $typeDefinition));
+
+        return [
+            'name' => $name,
+            'type' => $typeDefinition,
+            'type_name' => $typeName,
+            'nullable' => $nullable,
+            'default' => null,
+            'auto_increment' => false,
+            'comment' => $definition,
+            'generation' => null,
+        ];
+    }
+
+    private function normalizeIdentifier(string $identifier): string
+    {
+        if (! preg_match('/^[A-Za-z0-9_]+$/', $identifier)) {
+            throw new RuntimeException(sprintf('The Surreal schema identifier [%s] contains unsupported characters.', $identifier));
+        }
+
+        return $identifier;
+    }
+}

--- a/app/Services/Surreal/SurrealDocumentStore.php
+++ b/app/Services/Surreal/SurrealDocumentStore.php
@@ -20,7 +20,7 @@ class SurrealDocumentStore
     {
         try {
             return $this->normalizeRecordSet($this->run(sprintf('SELECT * FROM %s;', $this->normalizeTable($table)))[0] ?? []);
-        } catch (RuntimeException $exception) {
+        } catch (SurrealQueryException $exception) {
             if ($this->tableMissing($exception, $table)) {
                 return [];
             }
@@ -36,7 +36,7 @@ class SurrealDocumentStore
     {
         try {
             return $this->normalizeRecordSet($this->run(sprintf('SELECT * FROM %s;', $this->recordSelector($table, $id)))[0] ?? [])[0] ?? null;
-        } catch (RuntimeException $exception) {
+        } catch (SurrealQueryException $exception) {
             if ($this->tableMissing($exception, $table)) {
                 return null;
             }
@@ -217,8 +217,8 @@ class SurrealDocumentStore
         return array_keys($value) !== range(0, count($value) - 1);
     }
 
-    private function tableMissing(RuntimeException $exception, string $table): bool
+    private function tableMissing(SurrealQueryException $exception, string $table): bool
     {
-        return str_contains($exception->getMessage(), sprintf("table '%s' does not exist", $this->normalizeTable($table)));
+        return $exception->isTableMissing($this->normalizeTable($table));
     }
 }

--- a/app/Services/Surreal/SurrealDocumentStore.php
+++ b/app/Services/Surreal/SurrealDocumentStore.php
@@ -8,7 +8,7 @@ use RuntimeException;
 class SurrealDocumentStore
 {
     public function __construct(
-        private readonly SurrealCliClient $client,
+        private readonly SurrealHttpClient $client,
         private readonly SurrealConnection $connection,
         private readonly SurrealRuntimeManager $runtimeManager,
     ) {}
@@ -18,7 +18,15 @@ class SurrealDocumentStore
      */
     public function all(string $table): array
     {
-        return $this->normalizeRecordSet($this->run(sprintf('SELECT * FROM %s;', $this->normalizeTable($table)))[0] ?? []);
+        try {
+            return $this->normalizeRecordSet($this->run(sprintf('SELECT * FROM %s;', $this->normalizeTable($table)))[0] ?? []);
+        } catch (RuntimeException $exception) {
+            if ($this->tableMissing($exception, $table)) {
+                return [];
+            }
+
+            throw $exception;
+        }
     }
 
     /**
@@ -26,7 +34,15 @@ class SurrealDocumentStore
      */
     public function find(string $table, string $id): ?array
     {
-        return $this->normalizeRecordSet($this->run(sprintf('SELECT * FROM %s;', $this->recordSelector($table, $id)))[0] ?? [])[0] ?? null;
+        try {
+            return $this->normalizeRecordSet($this->run(sprintf('SELECT * FROM %s;', $this->recordSelector($table, $id)))[0] ?? [])[0] ?? null;
+        } catch (RuntimeException $exception) {
+            if ($this->tableMissing($exception, $table)) {
+                return null;
+            }
+
+            throw $exception;
+        }
     }
 
     /**
@@ -68,7 +84,7 @@ class SurrealDocumentStore
     private function run(string $query): array
     {
         if (! $this->runtimeManager->ensureReady()) {
-            throw new RuntimeException('The SurrealDB runtime is not available for the current CLI-backed driver. Install the `surreal` CLI and provide a reachable runtime, or switch to a future non-CLI driver.');
+            throw new RuntimeException('The SurrealDB runtime is not available for the current connection.');
         }
 
         return $this->client->runQuery(
@@ -199,5 +215,10 @@ class SurrealDocumentStore
         }
 
         return array_keys($value) !== range(0, count($value) - 1);
+    }
+
+    private function tableMissing(RuntimeException $exception, string $table): bool
+    {
+        return str_contains($exception->getMessage(), sprintf("table '%s' does not exist", $this->normalizeTable($table)));
     }
 }

--- a/app/Services/Surreal/SurrealHttpClient.php
+++ b/app/Services/Surreal/SurrealHttpClient.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Client\Factory;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Arr;
+use JsonException;
 use RuntimeException;
 use Throwable;
 
@@ -166,15 +167,22 @@ class SurrealHttpClient
             }
 
             if (($statement['status'] ?? null) !== 'OK') {
+                $codeName = Arr::get($statement, 'code');
                 $details = Arr::get($statement, 'detail')
                     ?? Arr::get($statement, 'result')
+                    ?? Arr::get($statement, 'information')
                     ?? 'unknown error';
 
-                throw new RuntimeException(sprintf(
-                    'The SurrealDB query statement at position %d failed (%s).',
-                    $index + 1,
-                    is_scalar($details) ? (string) $details : json_encode($details),
-                ));
+                throw new SurrealQueryException(
+                    message: sprintf(
+                        'The SurrealDB query statement at position %d failed (%s).',
+                        $index + 1,
+                        $this->stringifyDetails($details),
+                    ),
+                    codeName: is_string($codeName) ? $codeName : null,
+                    details: $details,
+                    statementIndex: $index + 1,
+                );
             }
         }
 
@@ -258,12 +266,18 @@ class SurrealHttpClient
     private function requestException(string $prefix, RequestException $exception): RuntimeException
     {
         $payload = $exception->response?->json();
+        $codeName = Arr::get($payload, 'code');
         $details = Arr::get($payload, 'information')
             ?? Arr::get($payload, 'details')
             ?? $exception->response?->body()
             ?? $exception->getMessage();
 
-        return new RuntimeException(sprintf('%s (%s).', $prefix, trim((string) $details)), previous: $exception);
+        return new SurrealQueryException(
+            message: sprintf('%s (%s).', $prefix, $this->stringifyDetails($details)),
+            codeName: is_string($codeName) ? $codeName : null,
+            details: $details,
+            previous: new RuntimeException($exception->getMessage(), previous: $exception),
+        );
     }
 
     /**
@@ -276,5 +290,20 @@ class SurrealHttpClient
         }
 
         return array_keys($value) !== range(0, count($value) - 1);
+    }
+
+    private function stringifyDetails(mixed $details): string
+    {
+        if (is_scalar($details) || $details === null) {
+            return trim((string) $details);
+        }
+
+        try {
+            $encoded = json_encode($details, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            return 'unserializable error details';
+        }
+
+        return is_string($encoded) ? $encoded : 'unknown error';
     }
 }

--- a/app/Services/Surreal/SurrealHttpClient.php
+++ b/app/Services/Surreal/SurrealHttpClient.php
@@ -1,0 +1,280 @@
+<?php
+
+namespace App\Services\Surreal;
+
+use Illuminate\Http\Client\Factory;
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Arr;
+use RuntimeException;
+use Throwable;
+
+class SurrealHttpClient
+{
+    /**
+     * @var array<string, true>
+     */
+    private array $preparedContexts = [];
+
+    public function __construct(
+        private readonly Factory $http,
+    ) {}
+
+    public function waitUntilReady(string $endpoint, int $attempts = 20, int $sleepMilliseconds = 250): bool
+    {
+        for ($attempt = 0; $attempt < $attempts; $attempt++) {
+            if ($this->isReady($endpoint)) {
+                return true;
+            }
+
+            usleep($sleepMilliseconds * 1000);
+        }
+
+        return false;
+    }
+
+    public function isReady(string $endpoint): bool
+    {
+        try {
+            return $this->http->acceptJson()
+                ->connectTimeout(2)
+                ->timeout(2)
+                ->get($this->healthUrl($endpoint))
+                ->successful();
+        } catch (Throwable) {
+            return false;
+        }
+    }
+
+    /**
+     * @return list<mixed>
+     */
+    public function runQuery(string $endpoint, string $namespace, string $database, string $username, string $password, string $query): array
+    {
+        $this->ensureContext(
+            endpoint: $endpoint,
+            namespace: $namespace,
+            database: $database,
+            username: $username,
+            password: $password,
+        );
+
+        try {
+            $response = $this->request(
+                endpoint: $endpoint,
+                namespace: $namespace,
+                database: $database,
+                username: $username,
+                password: $password,
+            )->withBody($query, 'text/plain')
+                ->post($this->sqlUrl($endpoint))
+                ->throw();
+        } catch (RequestException $exception) {
+            throw $this->requestException('Failed to execute the SurrealDB query', $exception);
+        }
+
+        return $this->normalizeResults($this->decodeResponse($response->json()));
+    }
+
+    private function ensureContext(string $endpoint, string $namespace, string $database, string $username, string $password): void
+    {
+        $cacheKey = implode('|', [$endpoint, $namespace, $database, $username]);
+
+        if (isset($this->preparedContexts[$cacheKey])) {
+            return;
+        }
+
+        $this->runContextStatement(
+            label: 'prepare the SurrealDB namespace',
+            endpoint: $endpoint,
+            request: $this->request(
+                endpoint: $endpoint,
+                namespace: null,
+                database: null,
+                username: $username,
+                password: $password,
+            )->withBody(
+                sprintf('DEFINE NAMESPACE IF NOT EXISTS %s;', $this->normalizeIdentifier($namespace, 'namespace')),
+                'text/plain',
+            ),
+        );
+
+        $this->runContextStatement(
+            label: 'prepare the SurrealDB database',
+            endpoint: $endpoint,
+            request: $this->request(
+                endpoint: $endpoint,
+                namespace: $namespace,
+                database: null,
+                username: $username,
+                password: $password,
+            )->withBody(
+                sprintf('DEFINE DATABASE IF NOT EXISTS %s;', $this->normalizeIdentifier($database, 'database')),
+                'text/plain',
+            ),
+        );
+
+        $this->preparedContexts[$cacheKey] = true;
+    }
+
+    private function runContextStatement(string $label, string $endpoint, PendingRequest $request): void
+    {
+        try {
+            $response = $request->post($this->sqlUrl($endpoint))->throw();
+        } catch (RequestException $exception) {
+            throw $this->requestException(sprintf('Failed to %s', $label), $exception);
+        }
+
+        $this->decodeResponse($response->json());
+    }
+
+    private function request(string $endpoint, ?string $namespace, ?string $database, string $username, string $password): PendingRequest
+    {
+        return $this->http->baseUrl($this->baseUrl($endpoint))
+            ->acceptJson()
+            ->connectTimeout(5)
+            ->timeout(30)
+            ->withBasicAuth($username, $password)
+            ->withHeaders(array_filter([
+                'Surreal-NS' => $namespace,
+                'Surreal-DB' => $database,
+            ], static fn (?string $value): bool => $value !== null && $value !== ''));
+    }
+
+    private function healthUrl(string $endpoint): string
+    {
+        return $this->baseUrl($endpoint).'/health';
+    }
+
+    private function sqlUrl(string $endpoint): string
+    {
+        return $this->baseUrl($endpoint).'/sql';
+    }
+
+    /**
+     * @return list<mixed>
+     */
+    private function decodeResponse(mixed $decoded): array
+    {
+        if (! is_array($decoded) || $decoded === []) {
+            throw new RuntimeException('Unable to decode the SurrealDB HTTP response.');
+        }
+
+        foreach ($decoded as $index => $statement) {
+            if (! is_array($statement)) {
+                continue;
+            }
+
+            if (($statement['status'] ?? null) !== 'OK') {
+                $details = Arr::get($statement, 'detail')
+                    ?? Arr::get($statement, 'result')
+                    ?? 'unknown error';
+
+                throw new RuntimeException(sprintf(
+                    'The SurrealDB query statement at position %d failed (%s).',
+                    $index + 1,
+                    is_scalar($details) ? (string) $details : json_encode($details),
+                ));
+            }
+        }
+
+        return $decoded;
+    }
+
+    /**
+     * @param  list<mixed>  $statements
+     * @return list<mixed>
+     */
+    private function normalizeResults(array $statements): array
+    {
+        return array_map(function (mixed $statement): mixed {
+            if (! is_array($statement)) {
+                return [];
+            }
+
+            return $this->normalizeStatementResult($statement['result'] ?? null);
+        }, $statements);
+    }
+
+    /**
+     * @return list<mixed>
+     */
+    private function normalizeStatementResult(mixed $result): array
+    {
+        if ($result === null) {
+            return [];
+        }
+
+        if (! is_array($result)) {
+            return [$result];
+        }
+
+        if ($this->isAssociative($result)) {
+            return [$result];
+        }
+
+        return $result;
+    }
+
+    private function baseUrl(string $endpoint): string
+    {
+        $parts = parse_url($endpoint);
+
+        if (! is_array($parts) || ! isset($parts['scheme'], $parts['host'])) {
+            throw new RuntimeException(sprintf('Unable to parse the SurrealDB endpoint [%s].', $endpoint));
+        }
+
+        $scheme = match ($parts['scheme']) {
+            'ws' => 'http',
+            'wss' => 'https',
+            default => $parts['scheme'],
+        };
+
+        $authority = $parts['host'];
+
+        if (isset($parts['port'])) {
+            $authority .= ':'.$parts['port'];
+        }
+
+        $path = trim((string) ($parts['path'] ?? ''), '/');
+
+        return sprintf(
+            '%s://%s%s',
+            $scheme,
+            $authority,
+            $path !== '' ? '/'.$path : '',
+        );
+    }
+
+    private function normalizeIdentifier(string $identifier, string $label): string
+    {
+        if (! preg_match('/^[A-Za-z0-9_]+$/', $identifier)) {
+            throw new RuntimeException(sprintf('The SurrealDB %s identifier [%s] contains unsupported characters.', $label, $identifier));
+        }
+
+        return $identifier;
+    }
+
+    private function requestException(string $prefix, RequestException $exception): RuntimeException
+    {
+        $payload = $exception->response?->json();
+        $details = Arr::get($payload, 'information')
+            ?? Arr::get($payload, 'details')
+            ?? $exception->response?->body()
+            ?? $exception->getMessage();
+
+        return new RuntimeException(sprintf('%s (%s).', $prefix, trim((string) $details)), previous: $exception);
+    }
+
+    /**
+     * @param  array<mixed>  $value
+     */
+    private function isAssociative(array $value): bool
+    {
+        if ($value === []) {
+            return false;
+        }
+
+        return array_keys($value) !== range(0, count($value) - 1);
+    }
+}

--- a/app/Services/Surreal/SurrealQueryException.php
+++ b/app/Services/Surreal/SurrealQueryException.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Services\Surreal;
+
+use RuntimeException;
+
+class SurrealQueryException extends RuntimeException
+{
+    public function __construct(
+        string $message,
+        public readonly ?string $codeName = null,
+        public readonly mixed $details = null,
+        public readonly ?int $statementIndex = null,
+        ?RuntimeException $previous = null,
+    ) {
+        parent::__construct($message, previous: $previous);
+    }
+
+    public function isTableMissing(string $table): bool
+    {
+        $normalizedTable = strtolower($table);
+
+        if (is_string($this->codeName) && strcasecmp($this->codeName, 'TABLE_NOT_FOUND') === 0) {
+            return true;
+        }
+
+        if (is_string($this->details)) {
+            $normalizedDetails = strtolower($this->details);
+
+            return str_contains($normalizedDetails, $normalizedTable)
+                && str_contains($normalizedDetails, 'does not exist');
+        }
+
+        return false;
+    }
+}

--- a/app/Services/Surreal/SurrealRuntimeManager.php
+++ b/app/Services/Surreal/SurrealRuntimeManager.php
@@ -11,20 +11,21 @@ class SurrealRuntimeManager
 {
     public function __construct(
         private readonly SurrealCliClient $client,
+        private readonly SurrealHttpClient $httpClient,
         private readonly SurrealConnection $connection,
     ) {}
 
     public function ensureReady(): bool
     {
-        if (! $this->client->isAvailable()) {
-            return false;
-        }
-
-        if ($this->client->isReady($this->connection->endpoint)) {
+        if ($this->httpClient->isReady($this->connection->endpoint)) {
             return true;
         }
 
         if (! $this->connection->usesLocalRuntime() || ! $this->connection->autostart) {
+            return false;
+        }
+
+        if (! $this->client->isAvailable()) {
             return false;
         }
 
@@ -44,7 +45,7 @@ class SurrealRuntimeManager
                 throw new RuntimeException(sprintf('Unable to lock the SurrealDB runtime lock file at [%s].', $lockPath));
             }
 
-            if ($this->client->isReady($this->connection->endpoint)) {
+            if ($this->httpClient->isReady($this->connection->endpoint)) {
                 return true;
             }
 
@@ -59,7 +60,7 @@ class SurrealRuntimeManager
 
             File::put($this->connection->runtimePidPath, (string) $pid);
 
-            return $this->client->waitUntilReady($this->connection->endpoint, attempts: 30, sleepMilliseconds: 250);
+            return $this->httpClient->waitUntilReady($this->connection->endpoint, attempts: 30, sleepMilliseconds: 250);
         } finally {
             flock($lockHandle, LOCK_UN);
             fclose($lockHandle);

--- a/config/database.php
+++ b/config/database.php
@@ -114,6 +114,11 @@ return [
             // 'trust_server_certificate' => env('DB_TRUST_SERVER_CERTIFICATE', 'false'),
         ],
 
+        'surreal' => [
+            'driver' => 'surreal',
+            'prefix' => '',
+        ],
+
     ],
 
     /*

--- a/config/surreal.php
+++ b/config/surreal.php
@@ -6,10 +6,10 @@ return [
     | SurrealDB Foundation Configuration
     |--------------------------------------------------------------------------
     |
-    | The first SurrealDB foundation for Katra uses the Surreal CLI as the
-    | runtime bridge. In local desktop development it can auto-start a local
-    | Surreal runtime when the CLI is available. Server deployments can point
-    | Laravel at an already-running SurrealDB endpoint instead.
+    | Katra talks to SurrealDB directly over HTTP for queries and schema work.
+    | In local desktop development it can still use the Surreal CLI to
+    | auto-start a local runtime when the CLI is available. Server
+    | deployments can point Laravel at an already-running SurrealDB endpoint.
     |
     */
 

--- a/tests/Feature/SurrealSchemaDriverTest.php
+++ b/tests/Feature/SurrealSchemaDriverTest.php
@@ -98,6 +98,7 @@ test('laravel can run and refresh the application migrations with surreal as the
     $storagePath = storage_path('app/surrealdb/schema-driver-migrate-test-'.Str::uuid());
     $originalDefaultConnection = config('database.default');
     $originalMigrationConnection = config('database.migrations.connection');
+    $expectedMigrationNames = expectedApplicationMigrationNames();
 
     File::deleteDirectory($storagePath);
     File::ensureDirectoryExists(dirname($storagePath));
@@ -140,7 +141,7 @@ test('laravel can run and refresh the application migrations with surreal as the
             ->and($schema->hasTable('features'))->toBeTrue()
             ->and($schema->hasTable('agent_conversations'))->toBeTrue()
             ->and($schema->hasTable('migrations'))->toBeTrue()
-            ->and($repository->getRan())->toHaveCount(5);
+            ->and($repository->getRan())->toEqualCanonicalizing($expectedMigrationNames);
 
         app()->forgetInstance('migration.repository');
         app()->forgetInstance('migrator');
@@ -157,7 +158,7 @@ test('laravel can run and refresh the application migrations with surreal as the
         expect($freshExitCode)->toBe(0)
             ->and($schema->hasTable('users'))->toBeTrue()
             ->and($schema->hasTable('migrations'))->toBeTrue()
-            ->and($repository->getRan())->toHaveCount(5);
+            ->and($repository->getRan())->toEqualCanonicalizing($expectedMigrationNames);
     } finally {
         config()->set('database.default', $originalDefaultConnection);
         config()->set('database.migrations.connection', $originalMigrationConnection);
@@ -183,7 +184,7 @@ function retryStartingSurrealSchemaServer(SurrealCliClient $client, string $stor
     $lastException = null;
 
     for ($attempt = 1; $attempt <= $attempts; $attempt++) {
-        $port = reserveSurrealSchemaPort();
+        $port = random_int(10240, 65535);
         $endpoint = sprintf('ws://127.0.0.1:%d', $port);
         $process = $client->startLocalServer(
             bindAddress: sprintf('127.0.0.1:%d', $port),
@@ -208,27 +209,14 @@ function retryStartingSurrealSchemaServer(SurrealCliClient $client, string $stor
     throw $lastException ?? new RuntimeException('Unable to start the SurrealDB schema test runtime.');
 }
 
-function reserveSurrealSchemaPort(): int
+/**
+ * @return array<int, string>
+ */
+function expectedApplicationMigrationNames(): array
 {
-    $socket = stream_socket_server('tcp://127.0.0.1:0', $errorCode, $errorMessage);
-
-    if ($socket === false) {
-        throw new RuntimeException(sprintf('Unable to reserve a free TCP port: %s (%d)', $errorMessage, $errorCode));
-    }
-
-    $address = stream_socket_get_name($socket, false);
-
-    fclose($socket);
-
-    if ($address === false) {
-        throw new RuntimeException('Unable to determine the reserved TCP port.');
-    }
-
-    $port = (int) ltrim((string) strrchr($address, ':'), ':');
-
-    if ($port <= 0) {
-        throw new RuntimeException(sprintf('Unable to parse the reserved TCP port from [%s].', $address));
-    }
-
-    return $port;
+    return collect(File::files(database_path('migrations')))
+        ->map(static fn (SplFileInfo $file): string => pathinfo($file->getFilename(), PATHINFO_FILENAME))
+        ->sort()
+        ->values()
+        ->all();
 }

--- a/tests/Feature/SurrealSchemaDriverTest.php
+++ b/tests/Feature/SurrealSchemaDriverTest.php
@@ -1,0 +1,225 @@
+<?php
+
+use App\Services\Surreal\SurrealCliClient;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+use Symfony\Component\Process\Process;
+
+test('laravel schema can create alter and drop surreal-backed tables', function () {
+    $client = app(SurrealCliClient::class);
+
+    if (! $client->isAvailable()) {
+        $this->markTestSkipped('The `surreal` CLI is not available in this environment.');
+    }
+
+    $storagePath = storage_path('app/surrealdb/schema-driver-test-'.Str::uuid());
+
+    File::deleteDirectory($storagePath);
+    File::ensureDirectoryExists(dirname($storagePath));
+
+    try {
+        $server = retryStartingSurrealSchemaServer($client, $storagePath);
+
+        config()->set('surreal.host', '127.0.0.1');
+        config()->set('surreal.port', $server['port']);
+        config()->set('surreal.endpoint', $server['endpoint']);
+        config()->set('surreal.username', 'root');
+        config()->set('surreal.password', 'root');
+        config()->set('surreal.namespace', 'katra');
+        config()->set('surreal.database', 'schema_driver_test');
+        config()->set('surreal.storage_engine', 'surrealkv');
+        config()->set('surreal.storage_path', $storagePath);
+        config()->set('surreal.runtime', 'local');
+        config()->set('surreal.autostart', false);
+
+        DB::purge('surreal');
+
+        $schema = Schema::connection('surreal');
+
+        $schema->create('conversation_nodes', function (Blueprint $table): void {
+            $table->string('title');
+            $table->text('summary')->nullable();
+            $table->boolean('open');
+            $table->timestamps();
+        });
+
+        expect($schema->hasTable('conversation_nodes'))->toBeTrue()
+            ->and($schema->hasColumns('conversation_nodes', [
+                'title',
+                'summary',
+                'open',
+                'created_at',
+                'updated_at',
+            ]))->toBeTrue()
+            ->and($schema->getColumnType('conversation_nodes', 'title'))->toBe('string')
+            ->and($schema->getColumnType('conversation_nodes', 'summary', fullDefinition: true))->toBe('none | string')
+            ->and($schema->getColumnType('conversation_nodes', 'open'))->toBe('bool')
+            ->and($schema->getColumnType('conversation_nodes', 'created_at'))->toBe('datetime');
+
+        $schema->table('conversation_nodes', function (Blueprint $table): void {
+            $table->string('status')->nullable();
+        });
+
+        expect($schema->hasColumn('conversation_nodes', 'status'))->toBeTrue()
+            ->and($schema->getColumnType('conversation_nodes', 'status', fullDefinition: true))->toBe('none | string');
+
+        $schema->table('conversation_nodes', function (Blueprint $table): void {
+            $table->dropColumn('status');
+        });
+
+        expect($schema->hasColumn('conversation_nodes', 'status'))->toBeFalse();
+
+        $schema->dropIfExists('conversation_nodes');
+
+        expect($schema->hasTable('conversation_nodes'))->toBeFalse();
+    } finally {
+        DB::purge('surreal');
+
+        if (isset($server['process'])) {
+            $server['process']->stop(1);
+        }
+
+        File::deleteDirectory($storagePath);
+    }
+});
+
+test('laravel can run and refresh the application migrations with surreal as the default connection', function () {
+    $client = app(SurrealCliClient::class);
+
+    if (! $client->isAvailable()) {
+        $this->markTestSkipped('The `surreal` CLI is not available in this environment.');
+    }
+
+    $storagePath = storage_path('app/surrealdb/schema-driver-migrate-test-'.Str::uuid());
+
+    File::deleteDirectory($storagePath);
+    File::ensureDirectoryExists(dirname($storagePath));
+
+    try {
+        $server = retryStartingSurrealSchemaServer($client, $storagePath);
+
+        config()->set('database.default', 'surreal');
+        config()->set('database.migrations.connection', null);
+
+        config()->set('surreal.host', '127.0.0.1');
+        config()->set('surreal.port', $server['port']);
+        config()->set('surreal.endpoint', $server['endpoint']);
+        config()->set('surreal.username', 'root');
+        config()->set('surreal.password', 'root');
+        config()->set('surreal.namespace', 'katra');
+        config()->set('surreal.database', 'schema_driver_migrate_test');
+        config()->set('surreal.storage_engine', 'surrealkv');
+        config()->set('surreal.storage_path', $storagePath);
+        config()->set('surreal.runtime', 'local');
+        config()->set('surreal.autostart', false);
+
+        DB::purge('surreal');
+        app()->forgetInstance('migration.repository');
+        app()->forgetInstance('migrator');
+
+        $migrateExitCode = Artisan::call('migrate', [
+            '--force' => true,
+            '--realpath' => true,
+            '--path' => database_path('migrations'),
+        ]);
+
+        $schema = Schema::connection('surreal');
+        $repository = app('migration.repository');
+
+        expect($migrateExitCode)->toBe(0)
+            ->and($schema->hasTable('users'))->toBeTrue()
+            ->and($schema->hasTable('cache'))->toBeTrue()
+            ->and($schema->hasTable('jobs'))->toBeTrue()
+            ->and($schema->hasTable('features'))->toBeTrue()
+            ->and($schema->hasTable('agent_conversations'))->toBeTrue()
+            ->and($schema->hasTable('migrations'))->toBeTrue()
+            ->and($repository->getRan())->toHaveCount(5);
+
+        app()->forgetInstance('migration.repository');
+        app()->forgetInstance('migrator');
+
+        $freshExitCode = Artisan::call('migrate:fresh', [
+            '--database' => 'surreal',
+            '--force' => true,
+            '--realpath' => true,
+            '--path' => database_path('migrations'),
+        ]);
+
+        $repository = app('migration.repository');
+
+        expect($freshExitCode)->toBe(0)
+            ->and($schema->hasTable('users'))->toBeTrue()
+            ->and($schema->hasTable('migrations'))->toBeTrue()
+            ->and($repository->getRan())->toHaveCount(5);
+    } finally {
+        DB::purge('surreal');
+
+        if (isset($server['process'])) {
+            $server['process']->stop(1);
+        }
+
+        File::deleteDirectory($storagePath);
+    }
+});
+
+/**
+ * @return array{endpoint: string, port: int, process: Process}
+ */
+function retryStartingSurrealSchemaServer(SurrealCliClient $client, string $storagePath, int $attempts = 3): array
+{
+    $lastException = null;
+
+    for ($attempt = 1; $attempt <= $attempts; $attempt++) {
+        $port = reserveSurrealSchemaPort();
+        $endpoint = sprintf('ws://127.0.0.1:%d', $port);
+        $process = $client->startLocalServer(
+            bindAddress: sprintf('127.0.0.1:%d', $port),
+            datastorePath: $storagePath,
+            username: 'root',
+            password: 'root',
+            storageEngine: 'surrealkv',
+        );
+
+        if ($client->waitUntilReady($endpoint)) {
+            return [
+                'endpoint' => $endpoint,
+                'port' => $port,
+                'process' => $process,
+            ];
+        }
+
+        $process->stop(1);
+        $lastException = new RuntimeException(sprintf('SurrealDB did not become ready on %s.', $endpoint));
+    }
+
+    throw $lastException ?? new RuntimeException('Unable to start the SurrealDB schema test runtime.');
+}
+
+function reserveSurrealSchemaPort(): int
+{
+    $socket = stream_socket_server('tcp://127.0.0.1:0', $errorCode, $errorMessage);
+
+    if ($socket === false) {
+        throw new RuntimeException(sprintf('Unable to reserve a free TCP port: %s (%d)', $errorMessage, $errorCode));
+    }
+
+    $address = stream_socket_get_name($socket, false);
+
+    fclose($socket);
+
+    if ($address === false) {
+        throw new RuntimeException('Unable to determine the reserved TCP port.');
+    }
+
+    $port = (int) ltrim((string) strrchr($address, ':'), ':');
+
+    if ($port <= 0) {
+        throw new RuntimeException(sprintf('Unable to parse the reserved TCP port from [%s].', $address));
+    }
+
+    return $port;
+}

--- a/tests/Feature/SurrealSchemaDriverTest.php
+++ b/tests/Feature/SurrealSchemaDriverTest.php
@@ -96,6 +96,8 @@ test('laravel can run and refresh the application migrations with surreal as the
     }
 
     $storagePath = storage_path('app/surrealdb/schema-driver-migrate-test-'.Str::uuid());
+    $originalDefaultConnection = config('database.default');
+    $originalMigrationConnection = config('database.migrations.connection');
 
     File::deleteDirectory($storagePath);
     File::ensureDirectoryExists(dirname($storagePath));
@@ -157,7 +159,12 @@ test('laravel can run and refresh the application migrations with surreal as the
             ->and($schema->hasTable('migrations'))->toBeTrue()
             ->and($repository->getRan())->toHaveCount(5);
     } finally {
+        config()->set('database.default', $originalDefaultConnection);
+        config()->set('database.migrations.connection', $originalMigrationConnection);
+
         DB::purge('surreal');
+        app()->forgetInstance('migration.repository');
+        app()->forgetInstance('migrator');
 
         if (isset($server['process'])) {
             $server['process']->stop(1);

--- a/tests/Feature/SurrealSchemaDriverTest.php
+++ b/tests/Feature/SurrealSchemaDriverTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Services\Surreal\SurrealCliClient;
+use App\Services\Surreal\SurrealHttpClient;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\DB;
@@ -171,6 +172,7 @@ test('laravel can run and refresh the application migrations with surreal as the
  */
 function retryStartingSurrealSchemaServer(SurrealCliClient $client, string $storagePath, int $attempts = 3): array
 {
+    $httpClient = app(SurrealHttpClient::class);
     $lastException = null;
 
     for ($attempt = 1; $attempt <= $attempts; $attempt++) {
@@ -184,7 +186,7 @@ function retryStartingSurrealSchemaServer(SurrealCliClient $client, string $stor
             storageEngine: 'surrealkv',
         );
 
-        if ($client->waitUntilReady($endpoint)) {
+        if ($httpClient->waitUntilReady($endpoint)) {
             return [
                 'endpoint' => $endpoint,
                 'port' => $port,

--- a/tests/Feature/SurrealWorkspaceModelTest.php
+++ b/tests/Feature/SurrealWorkspaceModelTest.php
@@ -4,6 +4,7 @@ use App\Models\Workspace;
 use App\Services\Surreal\SurrealCliClient;
 use App\Services\Surreal\SurrealConnection;
 use App\Services\Surreal\SurrealDocumentStore;
+use App\Services\Surreal\SurrealHttpClient;
 use App\Services\Surreal\SurrealRuntimeManager;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
@@ -143,6 +144,7 @@ test('the desktop preview workspace can be created through the surreal document 
  */
 function retryStartingWorkspaceServer(SurrealCliClient $client, string $storagePath, int $attempts = 3): array
 {
+    $httpClient = app(SurrealHttpClient::class);
     $lastException = null;
 
     for ($attempt = 1; $attempt <= $attempts; $attempt++) {
@@ -156,7 +158,7 @@ function retryStartingWorkspaceServer(SurrealCliClient $client, string $storageP
             storageEngine: 'surrealkv',
         );
 
-        if ($client->waitUntilReady($endpoint)) {
+        if ($httpClient->waitUntilReady($endpoint)) {
             return [
                 'endpoint' => $endpoint,
                 'port' => $port,

--- a/tests/Unit/SurrealHttpClientTest.php
+++ b/tests/Unit/SurrealHttpClientTest.php
@@ -1,0 +1,51 @@
+<?php
+
+use App\Services\Surreal\SurrealHttpClient;
+use Illuminate\Http\Client\Factory;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+uses(TestCase::class);
+
+test('it sends surreal queries over the http sql endpoint', function () {
+    Http::fake([
+        'http://127.0.0.1:18001/sql' => Http::response([
+            [
+                'status' => 'OK',
+                'result' => [
+                    ['id' => 'workspaces:test'],
+                ],
+            ],
+        ]),
+    ]);
+
+    $results = new SurrealHttpClient(app(Factory::class))->runQuery(
+        endpoint: 'ws://127.0.0.1:18001',
+        namespace: 'katra',
+        database: 'workspace',
+        username: 'root',
+        password: 'root',
+        query: 'SELECT * FROM workspaces;',
+    );
+
+    Http::assertSentCount(3);
+    Http::assertSent(function ($request): bool {
+        return $request->url() === 'http://127.0.0.1:18001/sql'
+            && $request->hasHeader('Surreal-NS', 'katra')
+            && $request->hasHeader('Surreal-DB', 'workspace')
+            && $request->body() === 'SELECT * FROM workspaces;';
+    });
+
+    expect($results)->toHaveCount(1)
+        ->and($results[0][0]['id'] ?? null)->toBe('workspaces:test');
+});
+
+test('it probes surreal health over http for websocket endpoints', function () {
+    Http::fake([
+        'http://127.0.0.1:18001/health' => Http::response(null, 200),
+    ]);
+
+    expect(new SurrealHttpClient(app(Factory::class))->isReady('ws://127.0.0.1:18001'))->toBeTrue();
+
+    Http::assertSent(fn ($request): bool => $request->url() === 'http://127.0.0.1:18001/health');
+});


### PR DESCRIPTION
## Summary
- register a first Laravel-compatible  database connection for schema work
- add a narrow Surreal schema grammar, builder, and manager for common Katra field types
- prove the flow with a real Surreal-backed Pest feature test and document the current scope

## Testing
- vendor/bin/pint --dirty --format agent
- php artisan test --compact tests/Feature/SurrealWorkspaceModelTest.php tests/Feature/SurrealSchemaDriverTest.php

Closes #113