### PR TITLE
chore: add DevOption to GitHub Sponsors funding config

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-github: [ibourgeois]
+github: [devoption, ibourgeois]


### PR DESCRIPTION
## Summary
- add the  GitHub Sponsors handle to 
- keep  as the secondary personal sponsor handle

Closes #115