### PR TITLE
fix: boot native surreal persistence during app startup

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -9,6 +9,7 @@ use App\Services\Surreal\SurrealConnection;
 use App\Services\Surreal\SurrealDocumentStore;
 use App\Services\Surreal\SurrealHttpClient;
 use App\Services\Surreal\SurrealRuntimeManager;
+use App\Support\Native\NativeRuntimePersistence;
 use Illuminate\Database\DatabaseManager;
 use Illuminate\Queue\QueueManager;
 use Illuminate\Session\DatabaseSessionHandler;
@@ -26,6 +27,8 @@ class AppServiceProvider extends ServiceProvider
 
     public function boot(): void
     {
+        $this->app->make(NativeRuntimePersistence::class)->configure();
+
         $this->app->extend('migration.repository', function ($repository, $app): SurrealMigrationRepository {
             $migrations = $app['config']['database.migrations'];
             $table = is_array($migrations) ? ($migrations['table'] ?? 'migrations') : $migrations;

--- a/app/Providers/NativeAppServiceProvider.php
+++ b/app/Providers/NativeAppServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace App\Providers;
 
-use App\Support\Native\NativeRuntimePersistence;
 use Native\Desktop\Contracts\ProvidesPhpIni;
 use Native\Desktop\Facades\Window;
 
@@ -10,8 +9,6 @@ class NativeAppServiceProvider implements ProvidesPhpIni
 {
     public function boot(): void
     {
-        app(NativeRuntimePersistence::class)->configure();
-
         Window::open()
             ->url(route('home'))
             ->title(config('app.name'))

--- a/tests/Feature/NativeRuntimePersistenceTest.php
+++ b/tests/Feature/NativeRuntimePersistenceTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Providers\AppServiceProvider;
 use App\Services\Surreal\SurrealCliClient;
 use App\Services\Surreal\SurrealConnection;
 use App\Services\Surreal\SurrealHttpClient;
@@ -61,7 +62,9 @@ test('the native runtime keeps auth, sessions, and cache state on surreal', func
         config()->set('queue.connections.surreal.connection', 'nativephp');
         config()->set('ai.caching.embeddings.store', 'database');
 
-        app(NativeRuntimePersistence::class)->configure();
+        expect(app(NativeRuntimePersistence::class))->not->toBeNull();
+
+        (new AppServiceProvider(app()))->boot();
 
         resetNativeRuntimePersistenceState();
 

--- a/tests/Feature/NativeRuntimePersistenceTest.php
+++ b/tests/Feature/NativeRuntimePersistenceTest.php
@@ -1,11 +1,9 @@
 <?php
 
-use App\Providers\AppServiceProvider;
 use App\Services\Surreal\SurrealCliClient;
 use App\Services\Surreal\SurrealConnection;
 use App\Services\Surreal\SurrealHttpClient;
 use App\Services\Surreal\SurrealRuntimeManager;
-use App\Support\Native\NativeRuntimePersistence;
 use Illuminate\Cache\FileStore;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Cache;
@@ -23,12 +21,21 @@ test('the native runtime keeps auth, sessions, and cache state on surreal', func
 
     $storagePath = storage_path('app/surrealdb/native-runtime-test-'.Str::uuid());
     $originalConfig = snapshotNativeRuntimeConfig();
+    $originalNativeRunning = env('NATIVEPHP_RUNNING');
+    $originalNativeStoragePath = env('NATIVEPHP_STORAGE_PATH');
+    $originalNativeDatabasePath = env('NATIVEPHP_DATABASE_PATH');
 
     File::deleteDirectory($storagePath);
     File::ensureDirectoryExists(dirname($storagePath));
 
     try {
         $server = retryStartingNativeRuntimeSurrealServer($client, $storagePath);
+
+        setNativeRuntimeEnvironment('NATIVEPHP_RUNNING', 'true');
+        setNativeRuntimeEnvironment('NATIVEPHP_STORAGE_PATH', storage_path('framework/testing/native-runtime-'.Str::uuid()));
+        setNativeRuntimeEnvironment('NATIVEPHP_DATABASE_PATH', database_path('native-runtime-test.sqlite'));
+
+        $this->refreshApplication();
 
         config()->set('surreal.host', '127.0.0.1');
         config()->set('surreal.port', $server['port']);
@@ -41,30 +48,8 @@ test('the native runtime keeps auth, sessions, and cache state on surreal', func
         config()->set('surreal.storage_path', $storagePath);
         config()->set('surreal.runtime', 'local');
         config()->set('surreal.autostart', false);
-
-        config()->set('nativephp-internal.running', true);
-        config()->set('database.default', 'nativephp');
-        config()->set('database.migrations.connection', 'nativephp');
-        config()->set('session.driver', 'file');
-        config()->set('session.connection', null);
         config()->set('session.table', 'sessions');
         config()->set('session.cookie', 'native-runtime-surreal');
-        config()->set('cache.default', 'database');
-        config()->set('cache.limiter', 'file');
-        config()->set('cache.stores.database.connection', 'nativephp');
-        config()->set('cache.stores.database.lock_connection', 'nativephp');
-        config()->set('cache.stores.surreal.connection', 'nativephp');
-        config()->set('cache.stores.surreal.lock_connection', 'nativephp');
-        config()->set('queue.default', 'database');
-        config()->set('queue.failed.database', 'nativephp');
-        config()->set('queue.batching.database', 'nativephp');
-        config()->set('queue.connections.database.connection', 'nativephp');
-        config()->set('queue.connections.surreal.connection', 'nativephp');
-        config()->set('ai.caching.embeddings.store', 'database');
-
-        expect(app(NativeRuntimePersistence::class))->not->toBeNull();
-
-        (new AppServiceProvider(app()))->boot();
 
         resetNativeRuntimePersistenceState();
 
@@ -76,7 +61,6 @@ test('the native runtime keeps auth, sessions, and cache state on surreal', func
             ->and(config('queue.default'))->toBe('surreal')
             ->and(config('queue.failed.database'))->toBe('surreal')
             ->and(config('queue.batching.database'))->toBe('surreal')
-            ->and(config('ai.caching.embeddings.store'))->toBe('surreal')
             ->and(cache()->driver(config('cache.limiter'))->getStore())->toBeInstanceOf(FileStore::class);
 
         expect(Artisan::call('migrate', [
@@ -123,6 +107,10 @@ test('the native runtime keeps auth, sessions, and cache state on surreal', func
             ->and(DB::connection('surreal')->table('sessions')->count())->toBeGreaterThan(0);
     } finally {
         restoreNativeRuntimeConfig($originalConfig);
+        setNativeRuntimeEnvironment('NATIVEPHP_RUNNING', $originalNativeRunning);
+        setNativeRuntimeEnvironment('NATIVEPHP_STORAGE_PATH', $originalNativeStoragePath);
+        setNativeRuntimeEnvironment('NATIVEPHP_DATABASE_PATH', $originalNativeDatabasePath);
+        $this->refreshApplication();
         resetNativeRuntimePersistenceState();
 
         if (isset($server['process'])) {
@@ -171,6 +159,20 @@ function restoreNativeRuntimeConfig(array $snapshot): void
     foreach ($snapshot as $key => $value) {
         config()->set($key, $value);
     }
+}
+
+function setNativeRuntimeEnvironment(string $key, string|false|null $value): void
+{
+    if ($value === false || $value === null) {
+        putenv($key);
+        unset($_ENV[$key], $_SERVER[$key]);
+
+        return;
+    }
+
+    putenv(sprintf('%s=%s', $key, $value));
+    $_ENV[$key] = $value;
+    $_SERVER[$key] = $value;
 }
 
 function resetNativeRuntimePersistenceState(): void


### PR DESCRIPTION
## Summary
- move the native Surreal persistence override into normal Laravel boot instead of the NativePHP window bootstrap hook
- keep the NativePHP provider focused on window setup only
- tighten the native runtime regression so it proves the override runs from real application startup

Closes #131

## Testing
- `'/Users/ibourgeois/Library/Application Support/Herd/bin/php84' artisan test --compact tests/Feature/NativeRuntimePersistenceTest.php tests/Feature/FortifyAuthenticationTest.php tests/Feature/SurrealSessionDriverTest.php tests/Feature/DatabaseCacheOnSurrealTest.php tests/Feature/SurrealQueueDriverTest.php`
