### PR TITLE
feat: add workspace-scoped private chats

### DIFF
--- a/app/Http/Controllers/ChatController.php
+++ b/app/Http/Controllers/ChatController.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\StoreWorkspaceChatRequest;
+use App\Models\InstanceConnection;
+use App\Models\WorkspaceChat;
+use App\Support\Chats\WorkspaceChatManager;
+use App\Support\Connections\InstanceConnectionManager;
+use App\Support\Connections\ViewerIdentityResolver;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+class ChatController extends Controller
+{
+    public function store(
+        StoreWorkspaceChatRequest $request,
+        InstanceConnectionManager $connectionManager,
+        ViewerIdentityResolver $viewerIdentityResolver,
+        WorkspaceChatManager $chatManager,
+    ): RedirectResponse {
+        $activeConnection = $connectionManager->activeConnectionFor(
+            $request->user(),
+            $request->root(),
+            $request->session(),
+        );
+
+        if ($activeConnection->kind === InstanceConnection::KIND_SERVER && ! $activeConnection->is_authenticated) {
+            return to_route('connections.connect', $activeConnection);
+        }
+
+        $workspaces = $connectionManager->workspacesFor($activeConnection);
+        $activeWorkspace = $connectionManager->activeWorkspaceFor($activeConnection, $workspaces);
+        $viewerIdentity = $viewerIdentityResolver->resolve($request->user(), $activeConnection);
+
+        $chatManager->createChat($activeWorkspace, $request->user(), $viewerIdentity, [
+            'name' => $request->validated('chat_name'),
+            'kind' => $request->validated('chat_kind'),
+        ]);
+
+        return to_route('home');
+    }
+
+    public function activate(
+        Request $request,
+        WorkspaceChat $workspaceChat,
+        WorkspaceChatManager $chatManager,
+    ): RedirectResponse {
+        if ((int) $workspaceChat->workspace->instanceConnection->user_id !== (int) $request->user()->getKey()) {
+            abort(404);
+        }
+
+        $chatManager->activateChat($workspaceChat);
+
+        return to_route('home');
+    }
+}

--- a/app/Http/Controllers/ChatMessageController.php
+++ b/app/Http/Controllers/ChatMessageController.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\StoreWorkspaceChatMessageRequest;
+use App\Models\WorkspaceChat;
+use App\Support\Chats\WorkspaceChatManager;
+use App\Support\Connections\ViewerIdentityResolver;
+use Illuminate\Http\RedirectResponse;
+
+class ChatMessageController extends Controller
+{
+    public function store(
+        StoreWorkspaceChatMessageRequest $request,
+        WorkspaceChat $workspaceChat,
+        ViewerIdentityResolver $viewerIdentityResolver,
+        WorkspaceChatManager $chatManager,
+    ): RedirectResponse {
+        if ((int) $workspaceChat->workspace->instanceConnection->user_id !== (int) $request->user()->getKey()) {
+            abort(404);
+        }
+
+        $viewerIdentity = $viewerIdentityResolver->resolve($request->user(), $workspaceChat->workspace->instanceConnection);
+
+        $chatManager->createMessage($workspaceChat, $request->user(), $viewerIdentity, [
+            'body' => $request->validated('message_body'),
+        ]);
+
+        return to_route('home');
+    }
+}

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -5,10 +5,14 @@ namespace App\Http\Controllers;
 use App\Features\Desktop\MvpShell;
 use App\Models\InstanceConnection;
 use App\Models\SurrealWorkspace;
-use App\Models\User;
 use App\Models\Workspace;
+use App\Models\WorkspaceChat;
+use App\Models\WorkspaceChatMessage;
+use App\Models\WorkspaceChatParticipant;
 use App\Services\Surreal\SurrealRuntimeManager;
+use App\Support\Chats\WorkspaceChatManager;
 use App\Support\Connections\InstanceConnectionManager;
+use App\Support\Connections\ViewerIdentityResolver;
 use App\Support\Features\DesktopUi;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Http\RedirectResponse;
@@ -305,65 +309,60 @@ class HomeController extends Controller
     }
 
     /**
-     * @param  array<int, array{label: string, meta: string}>  $participants
+     * @param  EloquentCollection<int, WorkspaceChat>  $chats
      * @return array<int, array{label: string, active?: bool, prefix: string, tone: string}>
      */
-    private function chatLinks(array $participants, string $viewerName): array
+    private function chatLinks(EloquentCollection $chats, WorkspaceChat $activeChat): array
     {
-        $links = [
-            ['label' => $viewerName, 'prefix' => substr($viewerName, 0, 1), 'tone' => 'human'],
-        ];
-
-        foreach ($participants as $participant) {
-            if ($participant['meta'] === 'Human') {
-                continue;
-            }
-
-            $links[] = [
-                'label' => $participant['label'],
-                'prefix' => '@',
-                'tone' => 'bot',
-            ];
-        }
-
-        return array_slice($links, 0, 3);
+        return $chats
+            ->map(fn (WorkspaceChat $chat): array => [
+                'label' => $chat->name,
+                'active' => (int) $chat->getKey() === (int) $activeChat->getKey(),
+                'prefix' => $chat->kind === WorkspaceChat::KIND_DIRECT ? '@' : strtoupper(substr($chat->name, 0, 1)),
+                'tone' => $chat->kind === WorkspaceChat::KIND_DIRECT ? 'human' : 'room',
+                'action' => (int) $chat->getKey() === (int) $activeChat->getKey() ? null : route('chats.activate', $chat),
+            ])
+            ->values()
+            ->all();
     }
 
     /**
-     * @param  array<int, array{label: string, meta: string}>  $participants
-     * @return array<int, array{
-     *     label: string,
-     *     value: string,
-     *     prefix: string,
-     *     tone: string,
-     *     subtitle: string
-     * }>
+     * @return array<int, array{label: string, meta: string}>
      */
-    private function chatContacts(array $participants, string $viewerName): array
+    private function chatParticipants(WorkspaceChat $chat): array
     {
-        $contacts = [[
-            'label' => $viewerName,
-            'value' => str($viewerName)->slug()->value(),
-            'prefix' => substr($viewerName, 0, 1),
-            'tone' => 'human',
-            'subtitle' => 'Human',
-        ]];
+        return $chat->participants
+            ->map(fn (WorkspaceChatParticipant $participant): array => [
+                'label' => $participant->display_name,
+                'meta' => $participant->participant_type === WorkspaceChatParticipant::TYPE_AGENT ? 'Agent' : 'Human',
+            ])
+            ->values()
+            ->all();
+    }
 
-        foreach ($participants as $participant) {
-            if ($participant['meta'] === 'Human') {
-                continue;
-            }
+    /**
+     * @return array<int, array{speaker: string, role: string, body: string, meta: string, tone: string}>
+     */
+    private function chatMessages(WorkspaceChat $chat): array
+    {
+        return $chat->messages
+            ->map(function (WorkspaceChatMessage $message): array {
+                $role = match ($message->sender_type) {
+                    WorkspaceChatMessage::SENDER_AGENT => 'Agent',
+                    WorkspaceChatMessage::SENDER_SYSTEM => 'System',
+                    default => 'Human',
+                };
 
-            $contacts[] = [
-                'label' => $participant['label'],
-                'value' => str($participant['label'])->slug()->value(),
-                'prefix' => '@',
-                'tone' => 'bot',
-                'subtitle' => $participant['meta'],
-            ];
-        }
-
-        return $contacts;
+                return [
+                    'speaker' => $message->sender_name,
+                    'role' => $role,
+                    'body' => $message->body,
+                    'meta' => $message->created_at?->diffForHumans() ?? 'Just now',
+                    'tone' => $role === 'Human' ? 'plain' : 'accent',
+                ];
+            })
+            ->values()
+            ->all();
     }
 
     /**
@@ -480,6 +479,8 @@ class HomeController extends Controller
         Request $request,
         SurrealRuntimeManager $runtimeManager,
         InstanceConnectionManager $connectionManager,
+        ViewerIdentityResolver $viewerIdentityResolver,
+        WorkspaceChatManager $chatManager,
     ): View|RedirectResponse {
         $localReady = false;
         $desktopUiStates = DesktopUi::states();
@@ -502,7 +503,7 @@ class HomeController extends Controller
             $request->session(),
         );
 
-        $viewerIdentity = $this->viewerIdentity($request->user(), $activeConnection);
+        $viewerIdentity = $viewerIdentityResolver->resolve($request->user(), $activeConnection);
         $viewerName = $viewerIdentity['name'];
 
         if ($activeConnection->kind === InstanceConnection::KIND_SERVER && ! $activeConnection->is_authenticated) {
@@ -513,6 +514,10 @@ class HomeController extends Controller
         $workspaces = $connectionManager->workspacesFor($activeConnection);
         $activeWorkspaceModel = $connectionManager->activeWorkspaceFor($activeConnection, $workspaces);
         $activeWorkspace = $this->activeWorkspaceState($activeConnection, $activeWorkspaceModel, $localReady);
+        $activeChatModel = $chatManager->activeChatFor($activeWorkspaceModel, $request->user(), $viewerIdentity);
+        $chats = $chatManager->chatsFor($activeWorkspaceModel);
+        $participants = $this->chatParticipants($activeChatModel);
+        $messages = $this->chatMessages($activeChatModel);
 
         return view('welcome', [
             'mvpShellEnabled' => $mvpShellEnabled,
@@ -521,13 +526,13 @@ class HomeController extends Controller
             'favoritesEnabled' => self::FAVORITES_ENABLED,
             'workspaceLinks' => $this->workspaceLinks($workspaces, $activeWorkspaceModel),
             'activeWorkspace' => $activeWorkspace,
+            'activeChat' => $activeChatModel,
             'favoriteLinks' => $this->favoriteLinks($activeWorkspace, $viewerName),
             'roomLinks' => $this->roomLinks($activeConnection, $activeWorkspace['room']),
-            'chatLinks' => $this->chatLinks($activeWorkspace['participants'], $viewerName),
-            'chatContacts' => $this->chatContacts($activeWorkspace['participants'], $viewerName),
+            'chatLinks' => $this->chatLinks($chats, $activeChatModel),
             'conversationNodeTabs' => $this->conversationNodeTabs($activeWorkspace),
-            'messages' => $activeWorkspace['messages'],
-            'participants' => $activeWorkspace['participants'],
+            'messages' => $messages,
+            'participants' => $participants,
             'viewerName' => $viewerIdentity['name'],
             'viewerEmail' => $viewerIdentity['email'],
             'viewerInitials' => $viewerIdentity['initials'],
@@ -550,59 +555,5 @@ class HomeController extends Controller
     private function connectionPrefix(InstanceConnection $connection): string
     {
         return strtoupper(substr($connection->name, 0, 1));
-    }
-
-    /**
-     * @return array{name: string, email: string, initials: string}
-     */
-    private function viewerIdentity(?User $viewer, InstanceConnection $activeConnection): array
-    {
-        $remoteIdentity = $activeConnection->kind === InstanceConnection::KIND_SERVER
-            ? data_get($activeConnection->session_context, 'user')
-            : null;
-        $remoteEmail = $activeConnection->kind === InstanceConnection::KIND_SERVER
-            ? data_get($activeConnection->session_context, 'email')
-            : null;
-        $remoteName = data_get($remoteIdentity, 'name');
-
-        if ((! is_string($remoteName) || $remoteName === '') && is_string($remoteEmail) && $remoteEmail !== '') {
-            $remoteName = $this->nameFromEmail($remoteEmail);
-        }
-
-        $name = $remoteName
-            ?: $viewer?->name
-            ?: 'Derek Bourgeois';
-
-        $email = data_get($remoteIdentity, 'email')
-            ?: $remoteEmail
-            ?: $viewer?->email
-            ?: 'derek@katra.io';
-
-        $initials = collect(preg_split('/\s+/', trim($name)) ?: [])
-            ->filter()
-            ->take(2)
-            ->map(fn (string $segment): string => strtoupper(substr($segment, 0, 1)))
-            ->implode('');
-
-        return [
-            'name' => $name,
-            'email' => $email,
-            'initials' => $initials !== '' ? $initials : 'K',
-        ];
-    }
-
-    private function nameFromEmail(string $email): string
-    {
-        $localPart = (string) str($email)->before('@');
-        $segments = preg_split('/[._-]+/', $localPart) ?: [];
-        $segments = array_values(array_filter(array_map(
-            fn (string $segment): string => str($segment)->title()->value(),
-            $segments,
-        )));
-
-        $firstName = $segments[0] ?? 'Remote';
-        $lastName = count($segments) > 1 ? implode(' ', array_slice($segments, 1)) : 'User';
-
-        return trim($firstName.' '.$lastName);
     }
 }

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -310,7 +310,7 @@ class HomeController extends Controller
 
     /**
      * @param  EloquentCollection<int, WorkspaceChat>  $chats
-     * @return array<int, array{label: string, active?: bool, prefix: string, tone: string}>
+     * @return array<int, array{label: string, active?: bool, prefix: string, tone: string, action?: string|null}>
      */
     private function chatLinks(EloquentCollection $chats, WorkspaceChat $activeChat): array
     {
@@ -345,7 +345,10 @@ class HomeController extends Controller
      */
     private function chatMessages(WorkspaceChat $chat): array
     {
-        return $chat->messages
+        return $chat->messages()
+            ->orderBy('created_at')
+            ->orderBy('id')
+            ->get()
             ->map(function (WorkspaceChatMessage $message): array {
                 $role = match ($message->sender_type) {
                     WorkspaceChatMessage::SENDER_AGENT => 'Agent',

--- a/app/Http/Requests/StoreWorkspaceChatMessageRequest.php
+++ b/app/Http/Requests/StoreWorkspaceChatMessageRequest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreWorkspaceChatMessageRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user() !== null;
+    }
+
+    /**
+     * @return array<string, ValidationRule|array<int, ValidationRule|string>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'message_body' => ['required', 'string', 'max:10000', 'regex:/\\S/'],
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'message_body.required' => 'Enter a message before sending it.',
+            'message_body.regex' => 'Messages cannot be blank.',
+        ];
+    }
+}

--- a/app/Http/Requests/StoreWorkspaceChatRequest.php
+++ b/app/Http/Requests/StoreWorkspaceChatRequest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreWorkspaceChatRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user() !== null;
+    }
+
+    /**
+     * @return array<string, ValidationRule|array<int, ValidationRule|string>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'chat_name' => ['required', 'string', 'max:255', 'regex:/\\S/'],
+            'chat_kind' => ['required', 'string', 'in:direct,group'],
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'chat_name.required' => 'Enter a chat name to create it in this workspace.',
+            'chat_name.regex' => 'Chat names cannot be blank.',
+            'chat_kind.required' => 'Choose whether this chat is direct or group.',
+            'chat_kind.in' => 'Chats must be direct or group conversations.',
+        ];
+    }
+}

--- a/app/Models/Workspace.php
+++ b/app/Models/Workspace.php
@@ -7,8 +7,9 @@ use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
-#[Fillable(['instance_connection_id', 'name', 'slug', 'summary'])]
+#[Fillable(['instance_connection_id', 'active_chat_id', 'name', 'slug', 'summary'])]
 class Workspace extends Model
 {
     /** @use HasFactory<WorkspaceFactory> */
@@ -22,5 +23,21 @@ class Workspace extends Model
     public function instanceConnection(): BelongsTo
     {
         return $this->belongsTo(InstanceConnection::class);
+    }
+
+    /**
+     * @return BelongsTo<WorkspaceChat, $this>
+     */
+    public function activeChat(): BelongsTo
+    {
+        return $this->belongsTo(WorkspaceChat::class, 'active_chat_id');
+    }
+
+    /**
+     * @return HasMany<WorkspaceChat, $this>
+     */
+    public function chats(): HasMany
+    {
+        return $this->hasMany(WorkspaceChat::class);
     }
 }

--- a/app/Models/WorkspaceChat.php
+++ b/app/Models/WorkspaceChat.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\WorkspaceChatFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+#[Fillable(['workspace_id', 'name', 'slug', 'kind', 'visibility', 'summary'])]
+class WorkspaceChat extends Model
+{
+    public const KIND_DIRECT = 'direct';
+
+    public const KIND_GROUP = 'group';
+
+    public const VISIBILITY_PRIVATE = 'private';
+
+    /** @use HasFactory<WorkspaceChatFactory> */
+    use HasFactory;
+
+    /**
+     * @return BelongsTo<Workspace, $this>
+     */
+    public function workspace(): BelongsTo
+    {
+        return $this->belongsTo(Workspace::class);
+    }
+
+    /**
+     * @return HasMany<WorkspaceChatParticipant, $this>
+     */
+    public function participants(): HasMany
+    {
+        return $this->hasMany(WorkspaceChatParticipant::class, 'chat_id');
+    }
+
+    /**
+     * @return HasMany<WorkspaceChatMessage, $this>
+     */
+    public function messages(): HasMany
+    {
+        return $this->hasMany(WorkspaceChatMessage::class, 'chat_id');
+    }
+}

--- a/app/Models/WorkspaceChatMessage.php
+++ b/app/Models/WorkspaceChatMessage.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\WorkspaceChatMessageFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+#[Fillable(['chat_id', 'sender_type', 'sender_key', 'sender_name', 'body'])]
+class WorkspaceChatMessage extends Model
+{
+    public const SENDER_HUMAN = 'human';
+
+    public const SENDER_AGENT = 'agent';
+
+    public const SENDER_SYSTEM = 'system';
+
+    /** @use HasFactory<WorkspaceChatMessageFactory> */
+    use HasFactory;
+
+    /**
+     * @return BelongsTo<WorkspaceChat, $this>
+     */
+    public function chat(): BelongsTo
+    {
+        return $this->belongsTo(WorkspaceChat::class, 'chat_id');
+    }
+}

--- a/app/Models/WorkspaceChatParticipant.php
+++ b/app/Models/WorkspaceChatParticipant.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\WorkspaceChatParticipantFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+#[Fillable(['chat_id', 'user_id', 'participant_type', 'participant_key', 'display_name'])]
+class WorkspaceChatParticipant extends Model
+{
+    public const TYPE_HUMAN = 'human';
+
+    public const TYPE_AGENT = 'agent';
+
+    /** @use HasFactory<WorkspaceChatParticipantFactory> */
+    use HasFactory;
+
+    /**
+     * @return BelongsTo<WorkspaceChat, $this>
+     */
+    public function chat(): BelongsTo
+    {
+        return $this->belongsTo(WorkspaceChat::class, 'chat_id');
+    }
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Support/Chats/WorkspaceChatManager.php
+++ b/app/Support/Chats/WorkspaceChatManager.php
@@ -1,0 +1,181 @@
+<?php
+
+namespace App\Support\Chats;
+
+use App\Models\User;
+use App\Models\Workspace;
+use App\Models\WorkspaceChat;
+use App\Models\WorkspaceChatMessage;
+use App\Models\WorkspaceChatParticipant;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Str;
+
+class WorkspaceChatManager
+{
+    /**
+     * @return Collection<int, WorkspaceChat>
+     */
+    public function chatsFor(Workspace $workspace): Collection
+    {
+        return $workspace->chats()
+            ->orderByDesc('updated_at')
+            ->orderBy('name')
+            ->get()
+            ->values();
+    }
+
+    /**
+     * @param  array{name: string, email: string, initials: string}  $viewerIdentity
+     * @param  Collection<int, WorkspaceChat>|null  $chats
+     */
+    public function activeChatFor(
+        Workspace $workspace,
+        User $viewer,
+        array $viewerIdentity,
+        ?Collection $chats = null,
+    ): WorkspaceChat {
+        $chats ??= $this->chatsFor($workspace);
+        $activeChat = $chats->firstWhere('id', $workspace->active_chat_id);
+
+        if (! $activeChat instanceof WorkspaceChat) {
+            $activeChat = $chats->first() ?? $this->createChat($workspace, $viewer, $viewerIdentity, [
+                'name' => 'General chat',
+                'kind' => WorkspaceChat::KIND_GROUP,
+            ]);
+        }
+
+        if ((int) $workspace->active_chat_id !== (int) $activeChat->getKey()) {
+            $workspace->forceFill([
+                'active_chat_id' => $activeChat->getKey(),
+            ])->save();
+        }
+
+        return $activeChat;
+    }
+
+    /**
+     * @param  array{name: string, email: string, initials: string}  $viewerIdentity
+     * @param  array{name: string, kind: string}  $attributes
+     */
+    public function createChat(
+        Workspace $workspace,
+        User $viewer,
+        array $viewerIdentity,
+        array $attributes,
+    ): WorkspaceChat {
+        $chatName = trim($attributes['name']);
+        $chatKind = $attributes['kind'] === WorkspaceChat::KIND_DIRECT
+            ? WorkspaceChat::KIND_DIRECT
+            : WorkspaceChat::KIND_GROUP;
+
+        $chat = $workspace->chats()->create([
+            'name' => $chatName,
+            'slug' => $this->nextChatSlug($workspace, $chatName),
+            'kind' => $chatKind,
+            'visibility' => WorkspaceChat::VISIBILITY_PRIVATE,
+            'summary' => $this->chatSummary($workspace, $chatName, $chatKind),
+        ]);
+
+        $chat->participants()->create($this->defaultParticipant($viewer, $viewerIdentity));
+
+        $workspace->forceFill([
+            'active_chat_id' => $chat->getKey(),
+        ])->save();
+
+        return $chat;
+    }
+
+    public function activateChat(WorkspaceChat $chat): void
+    {
+        $workspace = $chat->workspace;
+
+        if ((int) $workspace->active_chat_id !== (int) $chat->getKey()) {
+            $workspace->forceFill([
+                'active_chat_id' => $chat->getKey(),
+            ])->save();
+        }
+    }
+
+    /**
+     * @param  array{name: string, email: string, initials: string}  $viewerIdentity
+     * @param  array{body: string}  $attributes
+     */
+    public function createMessage(
+        WorkspaceChat $chat,
+        User $viewer,
+        array $viewerIdentity,
+        array $attributes,
+    ): WorkspaceChatMessage {
+        $message = $chat->messages()->create([
+            'sender_type' => WorkspaceChatMessage::SENDER_HUMAN,
+            'sender_key' => $this->participantKey($viewer, $viewerIdentity),
+            'sender_name' => $viewerIdentity['name'],
+            'body' => trim($attributes['body']),
+        ]);
+
+        $chat->touch();
+        $this->activateChat($chat);
+
+        return $message;
+    }
+
+    /**
+     * @param  array{name: string, email: string, initials: string}  $viewerIdentity
+     * @return array<string, int|string|null>
+     */
+    private function defaultParticipant(User $viewer, array $viewerIdentity): array
+    {
+        return [
+            'user_id' => $viewer->getKey(),
+            'participant_type' => WorkspaceChatParticipant::TYPE_HUMAN,
+            'participant_key' => $this->participantKey($viewer, $viewerIdentity),
+            'display_name' => $viewerIdentity['name'],
+        ];
+    }
+
+    /**
+     * @param  array{name: string, email: string, initials: string}  $viewerIdentity
+     */
+    private function participantKey(User $viewer, array $viewerIdentity): string
+    {
+        $email = trim((string) ($viewerIdentity['email'] ?? ''));
+
+        if ($email !== '') {
+            return 'human:'.Str::lower($email);
+        }
+
+        return 'human:user-'.$viewer->getKey();
+    }
+
+    private function nextChatSlug(Workspace $workspace, string $chatName): string
+    {
+        $baseSlug = Str::slug($chatName);
+        $baseSlug = $baseSlug !== '' ? $baseSlug : 'chat';
+        $slug = $baseSlug;
+        $suffix = 2;
+
+        while ($workspace->chats()->where('slug', $slug)->exists()) {
+            $slug = $baseSlug.'-'.$suffix;
+            $suffix++;
+        }
+
+        return $slug;
+    }
+
+    private function chatSummary(Workspace $workspace, string $chatName, string $chatKind): string
+    {
+        if ($chatKind === WorkspaceChat::KIND_DIRECT) {
+            return sprintf(
+                '%s is a private direct chat inside the %s workspace.',
+                $chatName,
+                $workspace->name,
+            );
+        }
+
+        return sprintf(
+            '%s is a private group chat inside the %s workspace.',
+            $chatName,
+            $workspace->name,
+        );
+    }
+}

--- a/app/Support/Connections/ViewerIdentityResolver.php
+++ b/app/Support/Connections/ViewerIdentityResolver.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Support\Connections;
+
+use App\Models\InstanceConnection;
+use App\Models\User;
+
+class ViewerIdentityResolver
+{
+    /**
+     * @return array{name: string, email: string, initials: string}
+     */
+    public function resolve(?User $viewer, InstanceConnection $activeConnection): array
+    {
+        $remoteIdentity = $activeConnection->kind === InstanceConnection::KIND_SERVER
+            ? data_get($activeConnection->session_context, 'user')
+            : null;
+        $remoteEmail = $activeConnection->kind === InstanceConnection::KIND_SERVER
+            ? data_get($activeConnection->session_context, 'email')
+            : null;
+        $remoteName = data_get($remoteIdentity, 'name');
+
+        if ((! is_string($remoteName) || $remoteName === '') && is_string($remoteEmail) && $remoteEmail !== '') {
+            $remoteName = $this->nameFromEmail($remoteEmail);
+        }
+
+        $name = $remoteName
+            ?: $viewer?->name
+            ?: 'Katra User';
+
+        $email = data_get($remoteIdentity, 'email')
+            ?: $remoteEmail
+            ?: $viewer?->email
+            ?: 'katra@example.test';
+
+        $initials = collect(preg_split('/\s+/', trim($name)) ?: [])
+            ->filter()
+            ->take(2)
+            ->map(fn (string $segment): string => strtoupper(substr($segment, 0, 1)))
+            ->implode('');
+
+        return [
+            'name' => $name,
+            'email' => $email,
+            'initials' => $initials !== '' ? $initials : 'K',
+        ];
+    }
+
+    private function nameFromEmail(string $email): string
+    {
+        $localPart = (string) str($email)->before('@');
+        $segments = preg_split('/[._-]+/', $localPart) ?: [];
+        $segments = array_values(array_filter(array_map(
+            fn (string $segment): string => str($segment)->title()->value(),
+            $segments,
+        )));
+
+        $firstName = $segments[0] ?? 'Remote';
+        $lastName = count($segments) > 1 ? implode(' ', array_slice($segments, 1)) : 'User';
+
+        return trim($firstName.' '.$lastName);
+    }
+}

--- a/database/factories/WorkspaceChatFactory.php
+++ b/database/factories/WorkspaceChatFactory.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Workspace;
+use App\Models\WorkspaceChat;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<WorkspaceChat>
+ */
+class WorkspaceChatFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $name = fake()->unique()->words(2, true);
+
+        return [
+            'workspace_id' => Workspace::factory(),
+            'name' => str($name)->title()->value(),
+            'slug' => Str::slug($name),
+            'kind' => WorkspaceChat::KIND_GROUP,
+            'visibility' => WorkspaceChat::VISIBILITY_PRIVATE,
+            'summary' => fake()->sentence(),
+        ];
+    }
+
+    public function direct(): static
+    {
+        return $this->state(fn (): array => [
+            'kind' => WorkspaceChat::KIND_DIRECT,
+        ]);
+    }
+}

--- a/database/factories/WorkspaceChatMessageFactory.php
+++ b/database/factories/WorkspaceChatMessageFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\WorkspaceChat;
+use App\Models\WorkspaceChatMessage;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<WorkspaceChatMessage>
+ */
+class WorkspaceChatMessageFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'chat_id' => WorkspaceChat::factory(),
+            'sender_type' => WorkspaceChatMessage::SENDER_HUMAN,
+            'sender_key' => 'human:'.fake()->uuid(),
+            'sender_name' => fake()->name(),
+            'body' => fake()->paragraph(),
+        ];
+    }
+}

--- a/database/factories/WorkspaceChatParticipantFactory.php
+++ b/database/factories/WorkspaceChatParticipantFactory.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\User;
+use App\Models\WorkspaceChat;
+use App\Models\WorkspaceChatParticipant;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<WorkspaceChatParticipant>
+ */
+class WorkspaceChatParticipantFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'chat_id' => WorkspaceChat::factory(),
+            'user_id' => User::factory(),
+            'participant_type' => WorkspaceChatParticipant::TYPE_HUMAN,
+            'participant_key' => 'human:'.fake()->unique()->safeEmail(),
+            'display_name' => fake()->name(),
+        ];
+    }
+
+    public function agent(): static
+    {
+        return $this->state(fn (): array => [
+            'user_id' => null,
+            'participant_type' => WorkspaceChatParticipant::TYPE_AGENT,
+            'participant_key' => 'agent:'.Str::slug(fake()->unique()->words(2, true)),
+            'display_name' => str(fake()->unique()->words(2, true))->title()->append(' Agent')->value(),
+        ]);
+    }
+}

--- a/database/migrations/2026_03_27_143418_create_workspace_chat_messages_table.php
+++ b/database/migrations/2026_03_27_143418_create_workspace_chat_messages_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        $driver = Schema::getConnection()->getDriverName();
+
+        Schema::create('workspace_chat_messages', function (Blueprint $table) use ($driver): void {
+            $table->id();
+            if ($driver === 'surreal') {
+                $table->unsignedBigInteger('chat_id');
+            } else {
+                $table->foreignId('chat_id')->constrained('workspace_chats')->cascadeOnDelete();
+            }
+            $table->string('sender_type', 25);
+            $table->string('sender_key')->nullable();
+            $table->string('sender_name');
+            $table->text('body');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('workspace_chat_messages');
+    }
+};

--- a/database/migrations/2026_03_27_143418_create_workspace_chat_participants_table.php
+++ b/database/migrations/2026_03_27_143418_create_workspace_chat_participants_table.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        $driver = Schema::getConnection()->getDriverName();
+
+        Schema::create('workspace_chat_participants', function (Blueprint $table) use ($driver): void {
+            $table->id();
+            if ($driver === 'surreal') {
+                $table->unsignedBigInteger('chat_id');
+                $table->unsignedBigInteger('user_id')->nullable();
+            } else {
+                $table->foreignId('chat_id')->constrained('workspace_chats')->cascadeOnDelete();
+                $table->foreignId('user_id')->nullable()->constrained()->nullOnDelete();
+            }
+            $table->string('participant_type', 25);
+            $table->string('participant_key');
+            $table->string('display_name');
+            $table->timestamps();
+
+            if ($driver !== 'surreal') {
+                $table->unique(['chat_id', 'participant_key'], 'workspace_chat_participants_chat_key_unique');
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('workspace_chat_participants');
+    }
+};

--- a/database/migrations/2026_03_27_143418_create_workspace_chats_table.php
+++ b/database/migrations/2026_03_27_143418_create_workspace_chats_table.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        $driver = Schema::getConnection()->getDriverName();
+
+        Schema::create('workspace_chats', function (Blueprint $table) use ($driver): void {
+            $table->id();
+            if ($driver === 'surreal') {
+                $table->unsignedBigInteger('workspace_id');
+            } else {
+                $table->foreignId('workspace_id')->constrained('connection_workspaces')->cascadeOnDelete();
+            }
+            $table->string('name');
+            $table->string('slug');
+            $table->string('kind', 25);
+            $table->string('visibility', 25);
+            $table->text('summary')->nullable();
+            $table->timestamps();
+
+            if ($driver !== 'surreal') {
+                $table->unique(['workspace_id', 'slug'], 'workspace_chats_workspace_slug_unique');
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('workspace_chats');
+    }
+};

--- a/database/migrations/2026_03_27_143427_add_active_chat_id_to_connection_workspaces_table.php
+++ b/database/migrations/2026_03_27_143427_add_active_chat_id_to_connection_workspaces_table.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        $driver = Schema::getConnection()->getDriverName();
+
+        Schema::table('connection_workspaces', function (Blueprint $table) use ($driver): void {
+            if ($driver === 'surreal') {
+                $table->unsignedBigInteger('active_chat_id')->nullable()->after('summary');
+            } else {
+                $table->foreignId('active_chat_id')
+                    ->nullable()
+                    ->after('summary')
+                    ->constrained('workspace_chats')
+                    ->nullOnDelete();
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        $driver = Schema::getConnection()->getDriverName();
+
+        Schema::table('connection_workspaces', function (Blueprint $table) use ($driver): void {
+            if ($driver !== 'surreal') {
+                $table->dropForeign(['active_chat_id']);
+            }
+
+            $table->dropColumn('active_chat_id');
+        });
+    }
+};

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -35,10 +35,16 @@
                             ],
                         ],
                         [
+                            'label' => 'Chats',
+                            'items' => [
+                                ['title' => $activeChat->name, 'meta' => 'Private chat', 'summary' => $activeChat->summary ?: 'The active private conversation for this workspace.'],
+                            ],
+                        ],
+                        [
                             'label' => 'People and agents',
                             'items' => [
                                 ['title' => $viewerName, 'meta' => 'Human', 'summary' => 'Direct conversation and workspace owner context.'],
-                                ['title' => 'Planner Agent', 'meta' => 'Worker', 'summary' => 'Planning and structuring support for the active room.'],
+                                ['title' => $participants[0]['label'] ?? $viewerName, 'meta' => $participants[0]['meta'] ?? 'Human', 'summary' => 'Participant in the active private chat.'],
                             ],
                         ],
                         [
@@ -50,35 +56,6 @@
                         ],
                     ];
 
-                    $conversationSeedMessages = collect($messages)
-                        ->values()
-                        ->map(fn (array $message, int $index): array => [
-                            'id' => 'seed-'.$index,
-                            'sender' => $message['speaker'],
-                            'role' => $message['role'],
-                            'meta' => $message['meta'],
-                            'body' => $message['body'],
-                            'direction' => $message['speaker'] === 'You' ? 'outgoing' : 'incoming',
-                            'attachments' => [],
-                        ])
-                        ->all();
-
-                    $conversationResponders = collect($participants)
-                        ->filter(fn (array $participant): bool => $participant['meta'] !== 'Human')
-                        ->values()
-                        ->map(fn (array $participant): array => [
-                            'label' => $participant['label'],
-                            'role' => $participant['meta'],
-                        ])
-                        ->all();
-
-                    $conversationMockReplies = [
-                        'I can break this into a couple of linked nodes without changing the flow of the room.',
-                        'That looks good. I would tighten the interaction first, then let the linked work follow behind it.',
-                        'We can keep the room focused and still attach the next task, artifact, or decision from the context rail.',
-                        'This conversation feels clearer when the structure stays quiet and the actions stay close to the composer.',
-                        'I can take the next pass on this and keep the changes scoped to the active conversation.',
-                    ];
                 @endphp
                 <div data-desktop-shell class="relative h-full overflow-hidden">
                     <div data-shell-grid class="grid h-full xl:grid-cols-[320px_minmax(0,1fr)]">
@@ -131,7 +108,14 @@
 
                                 <x-desktop.nav-section label="Chats" collapsible open action-label="Create chat" action-dialog-id="chat-creator-modal">
                                     @foreach ($chatLinks as $item)
-                                        <x-desktop.nav-item :label="$item['label']" :prefix="$item['prefix']" :tone="$item['tone']" :active="$item['active'] ?? false" :muted="$item['muted'] ?? false" />
+                                        <x-desktop.nav-item
+                                            :label="$item['label']"
+                                            :prefix="$item['prefix']"
+                                            :tone="$item['tone']"
+                                            :active="$item['active'] ?? false"
+                                            :muted="$item['muted'] ?? false"
+                                            :action="$item['action'] ?? null"
+                                        />
                                     @endforeach
                                 </x-desktop.nav-section>
                             </div>
@@ -238,6 +222,10 @@
                                 <p class="shell-text-soft mt-2 max-w-2xl text-sm leading-6">
                                     {{ $activeWorkspace['summary'] }}
                                 </p>
+                                <div class="mt-3 inline-flex items-center gap-2 rounded-full shell-elevated px-3 py-2">
+                                    <span class="shell-text-faint font-mono text-[10px] uppercase tracking-[0.12em]">Private chat</span>
+                                    <span class="shell-text text-sm font-medium">{{ $activeChat->name }}</span>
+                                </div>
                             </div>
                             </div>
                         </header>
@@ -248,9 +236,9 @@
                                     data-conversation-stream
                                     class="min-h-0 flex-1 space-y-4 overflow-y-auto px-1 pb-4"
                                 >
-                                    @foreach ($conversationSeedMessages as $message)
+                                    @forelse ($messages as $message)
                                         @php
-                                            $isOutgoing = $message['direction'] === 'outgoing';
+                                            $isOutgoing = $message['role'] === 'Human' && $message['speaker'] === $viewerName;
                                             $messageRoleTone = match ($message['role']) {
                                                 'Human' => 'shell-text-faint',
                                                 'Agent' => 'text-[color:var(--shell-accent)]',
@@ -262,7 +250,7 @@
                                         <article class="flex {{ $isOutgoing ? 'justify-end' : 'justify-start' }}">
                                             <div class="flex max-w-[78%] flex-col gap-2 {{ $isOutgoing ? 'items-end' : 'items-start' }}">
                                                 <div class="flex items-center gap-2 px-1">
-                                                    <span class="shell-text text-sm font-semibold">{{ $message['sender'] }}</span>
+                                                    <span class="shell-text text-sm font-semibold">{{ $message['speaker'] }}</span>
                                                     <span class="font-mono text-[10px] uppercase tracking-[0.12em] {{ $messageRoleTone }}">{{ $message['role'] }}</span>
                                                     <span class="shell-text-faint font-mono text-[10px] uppercase tracking-[0.12em]">{{ $message['meta'] }}</span>
                                                 </div>
@@ -272,61 +260,33 @@
                                                 </div>
                                             </div>
                                         </article>
-                                    @endforeach
+                                    @empty
+                                        <div class="shell-elevated rounded-[26px] px-5 py-5">
+                                            <p class="shell-text text-sm font-medium">{{ $activeChat->name }}</p>
+                                            <p class="shell-text-soft mt-2 text-sm leading-6">No messages yet. Start the conversation from this private chat and it will stay scoped to the {{ $activeWorkspace['label'] }} workspace.</p>
+                                        </div>
+                                    @endforelse
                                 </div>
 
-                                <div class="shell-surface mt-2 rounded-[26px] px-4 py-3">
-                                    <div data-message-attachments class="hidden flex-wrap gap-2 pb-3"></div>
-
-                                    <div
-                                        data-voice-indicator
-                                        class="shell-accent-soft shell-text hidden items-center gap-2 rounded-full px-3 py-2 text-sm font-medium"
-                                    >
-                                        <x-mdi-microphone class="h-4 w-4" />
-                                        <span>Voice mode selected</span>
-                                    </div>
+                                <form method="POST" action="{{ route('chats.messages.store', $activeChat) }}" class="shell-surface mt-2 rounded-[26px] px-4 py-3">
+                                    @csrf
 
                                     <textarea
+                                        name="message_body"
                                         data-message-input
                                         rows="1"
                                         class="shell-text min-h-[56px] w-full resize-none bg-transparent pt-1 text-[15px] leading-7 outline-none placeholder:text-[color:var(--shell-text-faint)]"
-                                        placeholder="Message {{ $activeWorkspace['label'] }}"
-                                        aria-label="Message {{ $activeWorkspace['label'] }}"
-                                    ></textarea>
+                                        placeholder="Message {{ $activeChat->name }}"
+                                        aria-label="Message {{ $activeChat->name }}"
+                                    >{{ old('message_body') }}</textarea>
 
-                                    <div class="mt-3 flex items-center justify-between gap-3">
-                                        <div class="flex items-center gap-2">
-                                            <input
-                                                type="file"
-                                                data-message-file-input
-                                                class="hidden"
-                                                multiple
-                                                aria-hidden="true"
-                                            />
-                                            <button
-                                                type="button"
-                                                data-attach-file
-                                                class="shell-elevated shell-hover-surface inline-flex h-10 w-10 items-center justify-center rounded-full transition-colors"
-                                                aria-label="Attach file"
-                                                title="Attach file"
-                                            >
-                                                <x-mdi-paperclip class="h-4 w-4" />
-                                            </button>
-                                            <button
-                                                type="button"
-                                                data-voice-toggle
-                                                class="shell-elevated shell-hover-surface inline-flex h-10 w-10 items-center justify-center rounded-full transition-colors"
-                                                aria-label="Toggle voice mode"
-                                                title="Toggle voice mode"
-                                                aria-pressed="false"
-                                            >
-                                                <x-mdi-microphone class="h-4 w-4" />
-                                            </button>
-                                        </div>
+                                    @error('message_body')
+                                        <p class="mt-2 text-sm text-[color:var(--shell-accent)]">{{ $message }}</p>
+                                    @enderror
 
+                                    <div class="mt-3 flex items-center justify-end gap-3">
                                         <button
-                                            type="button"
-                                            data-send-message
+                                            type="submit"
                                             class="shell-accent-chip inline-flex h-10 w-10 items-center justify-center rounded-full transition-colors hover:bg-[var(--shell-accent-hover)]"
                                             aria-label="Send message"
                                             title="Send message"
@@ -334,7 +294,7 @@
                                             <x-mdi-send class="h-4 w-4" />
                                         </button>
                                     </div>
-                                </div>
+                                </form>
                             </div>
                         </div>
                     </section>
@@ -806,62 +766,48 @@
             </form>
         </x-desktop.modal>
 
-        <x-desktop.modal id="chat-creator-modal" title="Start conversation" description="Select one or more contacts to open a conversation. This is demo-only for now.">
-            <form method="dialog" class="space-y-4">
-                <div data-contact-selector class="space-y-3">
-                    <div class="space-y-2">
-                        <label for="chat-contact-search" class="shell-text-faint font-mono text-[10px] uppercase tracking-[0.12em]">Contacts</label>
-                        <input
-                            id="chat-contact-search"
-                            type="text"
-                            data-contact-search
-                            class="shell-input shell-text w-full rounded-[18px] px-4 py-3 text-sm outline-none placeholder:text-[color:var(--shell-text-faint)]"
-                            placeholder="Search people, agents, and models"
-                        />
-                    </div>
+        <x-desktop.modal id="chat-creator-modal" title="Create chat" description="Start a private direct or group chat inside this workspace.">
+            <form method="POST" action="{{ route('chats.store') }}" class="space-y-4">
+                @csrf
 
-                    <div class="space-y-2">
-                        <p class="shell-text-faint font-mono text-[10px] uppercase tracking-[0.12em]">Selected</p>
-                        <div data-contact-selected class="flex min-h-14 flex-wrap gap-2 rounded-[18px] px-3 py-3 shell-input">
-                            <p data-contact-empty class="shell-text-subtle text-sm">No contacts selected yet.</p>
-                        </div>
-                    </div>
-
-                    <div class="space-y-2">
-                        <p class="shell-text-faint font-mono text-[10px] uppercase tracking-[0.12em]">Available contacts</p>
-                        <div data-contact-options class="max-h-64 space-y-2 overflow-y-auto pr-1">
-                            @foreach ($chatContacts as $contact)
-                                <button
-                                    type="button"
-                                    data-contact-option
-                                    data-contact-value="{{ $contact['value'] }}"
-                                    data-contact-label="{{ $contact['label'] }}"
-                                    class="shell-input flex w-full items-center gap-3 rounded-[18px] px-3 py-3 text-left transition-colors hover:bg-[var(--shell-elevated)]"
-                                >
-                                    <span @class([
-                                        'flex h-9 w-9 shrink-0 items-center justify-center rounded-xl font-mono text-sm uppercase',
-                                        'shell-human-chip' => $contact['tone'] === 'human',
-                                        'shell-bot-chip' => $contact['tone'] === 'bot',
-                                    ])>
-                                        {{ $contact['prefix'] }}
-                                    </span>
-                                    <span class="min-w-0 flex-1">
-                                        <span class="shell-text block truncate text-sm font-medium">{{ $contact['label'] }}</span>
-                                        <span class="shell-text-faint block text-xs">{{ $contact['subtitle'] }}</span>
-                                    </span>
-                                    <span class="shell-text-info-strong text-xs font-medium">Add</span>
-                                </button>
-                            @endforeach
-                        </div>
-                    </div>
+                <div class="space-y-2">
+                    <label for="chat-name" class="shell-text-faint font-mono text-[10px] uppercase tracking-[0.12em]">Chat name</label>
+                    <input
+                        id="chat-name"
+                        name="chat_name"
+                        type="text"
+                        value="{{ old('chat_name') }}"
+                        class="shell-input shell-text w-full rounded-[18px] px-4 py-3 text-sm outline-none placeholder:text-[color:var(--shell-text-faint)]"
+                        placeholder="Design review"
+                    />
+                    @error('chat_name')
+                        <p class="text-sm text-[color:var(--shell-accent)]">{{ $message }}</p>
+                    @enderror
                 </div>
+
+                <div class="space-y-2">
+                    <label for="chat-kind" class="shell-text-faint font-mono text-[10px] uppercase tracking-[0.12em]">Chat type</label>
+                    <select
+                        id="chat-kind"
+                        name="chat_kind"
+                        class="shell-input shell-text w-full rounded-[18px] px-4 py-3 text-sm outline-none"
+                    >
+                        <option value="direct" @selected(old('chat_kind') === 'direct')>Direct</option>
+                        <option value="group" @selected(old('chat_kind', 'group') === 'group')>Group</option>
+                    </select>
+                    @error('chat_kind')
+                        <p class="text-sm text-[color:var(--shell-accent)]">{{ $message }}</p>
+                    @enderror
+                </div>
+
+                <p class="shell-text-soft text-sm leading-6">Chats stay private to this workspace and are kept out of the shared workspace graph.</p>
 
                 <div class="flex items-center justify-end gap-3 pt-1">
                     <button type="button" data-dialog-close class="shell-icon-button rounded-full px-4 py-2 text-sm font-medium transition-colors">
                         Cancel
                     </button>
                     <button type="submit" class="shell-accent-chip rounded-full px-4 py-2 text-sm font-medium transition-colors hover:bg-[var(--shell-accent-hover)]">
-                        Start conversation
+                        Create chat
                     </button>
                 </div>
             </form>
@@ -885,12 +831,6 @@
                 const searchBackdrop = shell.querySelector('[data-search-backdrop]');
                 const conversationStream = shell.querySelector('[data-conversation-stream]');
                 const messageInput = shell.querySelector('[data-message-input]');
-                const sendMessageButton = shell.querySelector('[data-send-message]');
-                const attachFileButton = shell.querySelector('[data-attach-file]');
-                const messageFileInput = shell.querySelector('[data-message-file-input]');
-                const messageAttachments = shell.querySelector('[data-message-attachments]');
-                const voiceToggleButton = shell.querySelector('[data-voice-toggle]');
-                const voiceIndicator = shell.querySelector('[data-voice-indicator]');
                 const profileMenu = shell.querySelector('[data-profile-menu]');
                 const themeButtons = shell.querySelectorAll('[data-theme-option]');
                 const collapseButtons = shell.querySelectorAll('[data-sidebar-toggle]');
@@ -903,31 +843,22 @@
                 const dialogButtons = document.querySelectorAll('[data-dialog-target]');
                 const dialogCloseButtons = document.querySelectorAll('[data-dialog-close]');
                 const navSectionButtons = shell.querySelectorAll('[data-nav-section-toggle]');
-                const contactSelector = document.querySelector('[data-contact-selector]');
                 const storageKey = 'katra.desktop.sidebar.preference';
                 const rightRailStorageKey = 'katra.desktop.right-rail.preference';
                 const rightRailPinStorageKey = 'katra.desktop.right-rail.pin';
                 const rightRailWidthStorageKey = 'katra.desktop.right-rail.width';
-                const conversationStorageKey = @json('katra.desktop.conversation.' . $activeWorkspace['slug']);
                 const themeStorageKey = 'katra.desktop.theme.preference';
                 const autoCollapseWidth = 1480;
                 const rightRailAutoCollapseWidth = 1280;
                 const rightRailMinWidth = 280;
                 const rightRailMaxWidth = 560;
                 const systemThemeQuery = window.matchMedia('(prefers-color-scheme: dark)');
-                const conversationSeedMessages = @json($conversationSeedMessages ?? []);
-                const conversationResponders = @json($conversationResponders ?? []);
-                const conversationMockReplies = @json($conversationMockReplies ?? []);
 
                 let sidebarPreference = window.localStorage.getItem(storageKey);
                 let rightRailPreference = window.localStorage.getItem(rightRailStorageKey);
                 let rightRailPinned = window.localStorage.getItem(rightRailPinStorageKey) === 'true';
                 let rightRailWidth = Number.parseInt(window.localStorage.getItem(rightRailWidthStorageKey) ?? '320', 10);
                 let themePreference = window.localStorage.getItem(themeStorageKey) ?? 'system';
-                let conversationMessages = [];
-                let pendingAttachments = [];
-                let voiceModeEnabled = false;
-                let pendingResponseTimer = null;
 
                 if (Number.isNaN(rightRailWidth)) {
                     rightRailWidth = 320;
@@ -951,140 +882,6 @@
                     });
                 };
 
-                const conversationTimeFormatter = new Intl.DateTimeFormat([], {
-                    hour: 'numeric',
-                    minute: '2-digit',
-                });
-
-                const escapeHtml = (value) => String(value)
-                    .replaceAll('&', '&amp;')
-                    .replaceAll('<', '&lt;')
-                    .replaceAll('>', '&gt;')
-                    .replaceAll('"', '&quot;')
-                    .replaceAll("'", '&#039;');
-
-                const conversationStorageAvailable = () => typeof window.sessionStorage !== 'undefined';
-
-                const readConversationState = () => {
-                    if (! conversationStorageAvailable()) {
-                        return [...conversationSeedMessages];
-                    }
-
-                    const stored = window.sessionStorage.getItem(conversationStorageKey);
-
-                    if (! stored) {
-                        return [...conversationSeedMessages];
-                    }
-
-                    try {
-                        const decoded = JSON.parse(stored);
-
-                        return Array.isArray(decoded) ? decoded : [...conversationSeedMessages];
-                    } catch (error) {
-                        return [...conversationSeedMessages];
-                    }
-                };
-
-                const persistConversationState = () => {
-                    if (! conversationStorageAvailable()) {
-                        return;
-                    }
-
-                    window.sessionStorage.setItem(conversationStorageKey, JSON.stringify(conversationMessages));
-                };
-
-                const timestampLabel = () => conversationTimeFormatter.format(new Date());
-
-                const participantTone = (role) => {
-                    if (role === 'Human') {
-                        return 'shell-human-chip';
-                    }
-
-                    return 'shell-bot-chip';
-                };
-
-                const participantPrefix = (sender, role) => {
-                    if (role === 'Human') {
-                        return sender.slice(0, 1).toUpperCase();
-                    }
-
-                    return '@';
-                };
-
-                const roleTone = (role) => {
-                    if (role === 'Agent') {
-                        return 'text-[color:var(--shell-accent)]';
-                    }
-
-                    if (role === 'Model' || role === 'Worker') {
-                        return 'shell-text-info-strong';
-                    }
-
-                    return 'shell-text-faint';
-                };
-
-                const attachmentMarkup = (attachments = []) => {
-                    if (! Array.isArray(attachments) || attachments.length === 0) {
-                        return '';
-                    }
-
-                    return `
-                        <div class="mt-3 flex flex-wrap gap-2">
-                            ${attachments.map((attachment) => `
-                                <span class="shell-elevated inline-flex items-center gap-2 rounded-full px-3 py-2 text-sm">
-                                    <span class="shell-text">${escapeHtml(attachment.name)}</span>
-                                    <span class="shell-text-faint font-mono text-[10px] uppercase tracking-[0.12em]">Mock</span>
-                                </span>
-                            `).join('')}
-                        </div>
-                    `;
-                };
-
-                const buildConversationMessage = (message) => {
-                    const outgoing = message.direction === 'outgoing';
-                    const bubbleTone = outgoing ? 'shell-accent-soft' : 'shell-elevated';
-                    const align = outgoing ? 'justify-end' : 'justify-start';
-                    const itemAlign = outgoing ? 'items-end' : 'items-start';
-                    const avatarTone = participantTone(message.role);
-                    const statusTone = roleTone(message.role);
-                    const bodyMarkup = message.typing
-                        ? `
-                            <div class="shell-text-soft flex items-center gap-2 text-sm leading-7">
-                                <span class="inline-flex items-center gap-1">
-                                    <span class="h-1.5 w-1.5 rounded-full bg-[color:var(--shell-text-soft)]"></span>
-                                    <span class="h-1.5 w-1.5 rounded-full bg-[color:var(--shell-text-soft)]"></span>
-                                    <span class="h-1.5 w-1.5 rounded-full bg-[color:var(--shell-text-soft)]"></span>
-                                </span>
-                                <span>Thinking</span>
-                            </div>
-                        `
-                        : message.body
-                            ? `<p class="shell-text text-[15px] leading-7 whitespace-pre-wrap">${escapeHtml(message.body)}</p>`
-                            : '';
-
-                    return `
-                        <article class="flex ${align}">
-                            <div class="flex max-w-[82%] flex-col gap-2 ${itemAlign}">
-                                <div class="flex items-center gap-2 px-1">
-                                    ${outgoing ? '' : `
-                                        <span class="${avatarTone} flex h-7 w-7 items-center justify-center rounded-full font-mono text-xs uppercase">
-                                            ${escapeHtml(participantPrefix(message.sender, message.role))}
-                                        </span>
-                                    `}
-                                    <span class="shell-text text-sm font-semibold">${escapeHtml(message.sender)}</span>
-                                    <span class="font-mono text-[10px] uppercase tracking-[0.12em] ${statusTone}">${escapeHtml(message.role)}</span>
-                                    <span class="shell-text-faint font-mono text-[10px] uppercase tracking-[0.12em]">${escapeHtml(message.meta ?? '')}</span>
-                                </div>
-
-                                <div class="${bubbleTone} w-full rounded-[26px] px-4 py-3">
-                                    ${bodyMarkup}
-                                    ${attachmentMarkup(message.attachments)}
-                                </div>
-                            </div>
-                        </article>
-                    `;
-                };
-
                 const scrollConversationToBottom = () => {
                     if (! conversationStream) {
                         return;
@@ -1095,15 +892,6 @@
                     });
                 };
 
-                const renderConversation = () => {
-                    if (! conversationStream) {
-                        return;
-                    }
-
-                    conversationStream.innerHTML = conversationMessages.map(buildConversationMessage).join('');
-                    scrollConversationToBottom();
-                };
-
                 const syncComposerHeight = () => {
                     if (! messageInput) {
                         return;
@@ -1111,129 +899,6 @@
 
                     messageInput.style.height = '0px';
                     messageInput.style.height = `${Math.min(messageInput.scrollHeight, 160)}px`;
-                };
-
-                const renderPendingAttachments = () => {
-                    if (! messageAttachments) {
-                        return;
-                    }
-
-                    if (pendingAttachments.length === 0) {
-                        messageAttachments.classList.add('hidden');
-                        messageAttachments.innerHTML = '';
-
-                        return;
-                    }
-
-                    messageAttachments.classList.remove('hidden');
-                    messageAttachments.innerHTML = pendingAttachments.map((attachment) => `
-                        <button
-                            type="button"
-                            class="shell-elevated inline-flex items-center gap-2 rounded-full px-3 py-2 text-sm transition-colors hover:bg-[var(--shell-surface)]"
-                            data-remove-attachment="${escapeHtml(attachment.id)}"
-                        >
-                            <span class="shell-text">${escapeHtml(attachment.name)}</span>
-                            <span class="shell-text-faint text-xs" aria-hidden="true">×</span>
-                        </button>
-                    `).join('');
-                };
-
-                const applyVoiceState = () => {
-                    if (! voiceToggleButton) {
-                        return;
-                    }
-
-                    voiceToggleButton.classList.toggle('shell-accent-chip', voiceModeEnabled);
-                    voiceToggleButton.classList.toggle('shell-elevated', ! voiceModeEnabled);
-                    voiceToggleButton.setAttribute('aria-pressed', voiceModeEnabled ? 'true' : 'false');
-
-                    if (voiceIndicator) {
-                        voiceIndicator.classList.toggle('hidden', ! voiceModeEnabled);
-                        voiceIndicator.classList.toggle('flex', voiceModeEnabled);
-                    }
-                };
-
-                const nextAgentReply = () => {
-                    const responder = conversationResponders[Math.floor(Math.random() * conversationResponders.length)] ?? {
-                        label: 'Katra Agent',
-                        role: 'Agent',
-                    };
-                    const body = conversationMockReplies[Math.floor(Math.random() * conversationMockReplies.length)];
-
-                    return {
-                        id: `reply-${Date.now()}`,
-                        sender: responder.label,
-                        role: responder.role === 'Worker' ? 'Agent' : responder.role,
-                        meta: timestampLabel(),
-                        body,
-                        direction: 'incoming',
-                        attachments: [],
-                    };
-                };
-
-                const queueMockResponse = () => {
-                    if (pendingResponseTimer) {
-                        window.clearTimeout(pendingResponseTimer);
-                    }
-
-                    const typingMessage = {
-                        id: `typing-${Date.now()}`,
-                        sender: conversationResponders[0]?.label ?? 'Katra Agent',
-                        role: 'Agent',
-                        meta: 'Thinking',
-                        body: '',
-                        direction: 'incoming',
-                        attachments: [],
-                        typing: true,
-                    };
-
-                    conversationMessages.push(typingMessage);
-                    renderConversation();
-                    persistConversationState();
-
-                    pendingResponseTimer = window.setTimeout(() => {
-                        conversationMessages = conversationMessages.filter((message) => ! message.typing);
-                        conversationMessages.push(nextAgentReply());
-                        renderConversation();
-                        persistConversationState();
-                    }, 850);
-                };
-
-                const submitConversationMessage = () => {
-                    if (! messageInput) {
-                        return;
-                    }
-
-                    const body = messageInput.value.trim();
-
-                    if (body === '' && pendingAttachments.length === 0 && ! voiceModeEnabled) {
-                        return;
-                    }
-
-                    const attachments = pendingAttachments.map((attachment) => ({
-                        name: attachment.name,
-                    }));
-
-                    const outgoingMessage = {
-                        id: `message-${Date.now()}`,
-                        sender: 'You',
-                        role: 'Human',
-                        meta: timestampLabel(),
-                        body: body === '' && voiceModeEnabled ? 'Voice mode selected for this reply.' : body,
-                        direction: 'outgoing',
-                        attachments,
-                    };
-
-                    conversationMessages.push(outgoingMessage);
-                    messageInput.value = '';
-                    pendingAttachments = [];
-                    voiceModeEnabled = false;
-                    renderPendingAttachments();
-                    applyVoiceState();
-                    syncComposerHeight();
-                    renderConversation();
-                    persistConversationState();
-                    queueMockResponse();
                 };
 
                 const openSearchOverlay = () => {
@@ -1581,97 +1246,6 @@
                     });
                 });
 
-                if (contactSelector) {
-                    const searchInput = contactSelector.querySelector('[data-contact-search]');
-                    const selectedContainer = contactSelector.querySelector('[data-contact-selected]');
-                    const emptyState = contactSelector.querySelector('[data-contact-empty]');
-                    const optionButtons = Array.from(contactSelector.querySelectorAll('[data-contact-option]'));
-                    const selectedContacts = new Map();
-
-                    const renderSelectedContacts = () => {
-                        if (! selectedContainer) {
-                            return;
-                        }
-
-                        selectedContainer.querySelectorAll('[data-contact-chip]').forEach((chip) => chip.remove());
-
-                        if (selectedContacts.size === 0) {
-                            emptyState?.classList.remove('hidden');
-
-                            return;
-                        }
-
-                        emptyState?.classList.add('hidden');
-
-                        selectedContacts.forEach((contact) => {
-                            const chip = document.createElement('button');
-                            chip.type = 'button';
-                            chip.dataset.contactChip = contact.value;
-                            chip.className = 'shell-accent-soft inline-flex items-center gap-2 rounded-full px-3 py-2 text-sm font-medium';
-                            chip.innerHTML = `
-                                <span>${contact.label}</span>
-                                <span aria-hidden="true" class="shell-text-faint text-xs">×</span>
-                            `;
-
-                            chip.addEventListener('click', () => {
-                                selectedContacts.delete(contact.value);
-                                renderSelectedContacts();
-                                renderContactOptions(searchInput?.value ?? '');
-                            });
-
-                            selectedContainer.appendChild(chip);
-                        });
-                    };
-
-                    const renderContactOptions = (query = '') => {
-                        const normalizedQuery = query.trim().toLowerCase();
-
-                        optionButtons.forEach((button) => {
-                            const value = button.dataset.contactValue ?? '';
-                            const label = (button.dataset.contactLabel ?? '').toLowerCase();
-                            const matchesQuery = normalizedQuery === '' || label.includes(normalizedQuery);
-                            const selected = selectedContacts.has(value);
-
-                            button.classList.toggle('hidden', ! matchesQuery);
-                            button.classList.toggle('opacity-60', selected);
-                            button.setAttribute('aria-pressed', selected ? 'true' : 'false');
-
-                            const action = button.querySelector('.shell-text-info-strong');
-
-                            if (action) {
-                                action.textContent = selected ? 'Selected' : 'Add';
-                            }
-                        });
-                    };
-
-                    optionButtons.forEach((button) => {
-                        button.addEventListener('click', () => {
-                            const value = button.dataset.contactValue ?? '';
-                            const label = button.dataset.contactLabel ?? '';
-
-                            if (! value || ! label) {
-                                return;
-                            }
-
-                            if (selectedContacts.has(value)) {
-                                selectedContacts.delete(value);
-                            } else {
-                                selectedContacts.set(value, { value, label });
-                            }
-
-                            renderSelectedContacts();
-                            renderContactOptions(searchInput?.value ?? '');
-                        });
-                    });
-
-                    searchInput?.addEventListener('input', (event) => {
-                        renderContactOptions(event.target.value ?? '');
-                    });
-
-                    renderSelectedContacts();
-                    renderContactOptions();
-                }
-
                 shell.querySelectorAll('[data-node-tabs]').forEach((nodeTabs) => {
                     const buttons = Array.from(nodeTabs.querySelectorAll('[data-node-tab-button]'));
                     const panels = Array.from(nodeTabs.querySelectorAll('[data-node-tab-panel]'));
@@ -1709,73 +1283,11 @@
                     });
                 });
 
-                conversationMessages = readConversationState();
-                persistConversationState();
-                renderConversation();
-                renderPendingAttachments();
-                applyVoiceState();
+                scrollConversationToBottom();
                 syncComposerHeight();
 
                 messageInput?.addEventListener('input', () => {
                     syncComposerHeight();
-                });
-
-                messageInput?.addEventListener('keydown', (event) => {
-                    if (event.key === 'Enter' && ! event.shiftKey) {
-                        event.preventDefault();
-                        submitConversationMessage();
-                    }
-                });
-
-                sendMessageButton?.addEventListener('click', () => {
-                    submitConversationMessage();
-                });
-
-                attachFileButton?.addEventListener('click', () => {
-                    messageFileInput?.click();
-                });
-
-                messageFileInput?.addEventListener('change', (event) => {
-                    const target = event.target;
-
-                    if (! (target instanceof HTMLInputElement) || ! target.files) {
-                        return;
-                    }
-
-                    pendingAttachments = [
-                        ...pendingAttachments,
-                        ...Array.from(target.files).map((file, index) => ({
-                            id: `${Date.now()}-${index}-${file.name}`,
-                            name: file.name,
-                        })),
-                    ];
-
-                    renderPendingAttachments();
-                    target.value = '';
-                });
-
-                messageAttachments?.addEventListener('click', (event) => {
-                    const target = event.target;
-
-                    if (! (target instanceof HTMLElement)) {
-                        return;
-                    }
-
-                    const removeButton = target.closest('[data-remove-attachment]');
-
-                    if (! removeButton) {
-                        return;
-                    }
-
-                    const attachmentId = removeButton.getAttribute('data-remove-attachment');
-
-                    pendingAttachments = pendingAttachments.filter((attachment) => attachment.id !== attachmentId);
-                    renderPendingAttachments();
-                });
-
-                voiceToggleButton?.addEventListener('click', () => {
-                    voiceModeEnabled = ! voiceModeEnabled;
-                    applyVoiceState();
                 });
 
                 themeButtons.forEach((button) => {

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Http\Controllers\ChatController;
+use App\Http\Controllers\ChatMessageController;
 use App\Http\Controllers\HomeController;
 use App\Http\Controllers\InstanceConnectionController;
 use App\Http\Controllers\WorkspaceController;
@@ -23,4 +25,7 @@ Route::middleware('auth')->group(function (): void {
     Route::post('/connections/{instanceConnection}/connect', [InstanceConnectionController::class, 'authenticate'])->name('connections.authenticate');
     Route::post('/workspaces', [WorkspaceController::class, 'store'])->name('workspaces.store');
     Route::post('/workspaces/{workspace}/activate', [WorkspaceController::class, 'activate'])->name('workspaces.activate');
+    Route::post('/chats', [ChatController::class, 'store'])->name('chats.store');
+    Route::post('/chats/{workspaceChat}/activate', [ChatController::class, 'activate'])->name('chats.activate');
+    Route::post('/chats/{workspaceChat}/messages', [ChatMessageController::class, 'store'])->name('chats.messages.store');
 });

--- a/tests/Feature/DesktopShellTest.php
+++ b/tests/Feature/DesktopShellTest.php
@@ -3,6 +3,9 @@
 use App\Models\InstanceConnection;
 use App\Models\User;
 use App\Models\Workspace;
+use App\Models\WorkspaceChat;
+use App\Models\WorkspaceChatMessage;
+use App\Models\WorkspaceChatParticipant;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
 use function Pest\Laravel\actingAs;
@@ -50,9 +53,47 @@ test('the desktop shell exposes the connection-aware workspace shell', function 
         'name' => 'General',
         'slug' => 'general',
     ]);
+    $activeChat = WorkspaceChat::factory()->for($activeWorkspace, 'workspace')->create([
+        'name' => 'Design Review',
+        'slug' => 'design-review',
+        'kind' => WorkspaceChat::KIND_GROUP,
+        'visibility' => WorkspaceChat::VISIBILITY_PRIVATE,
+    ]);
+    WorkspaceChat::factory()->for($activeWorkspace, 'workspace')->direct()->create([
+        'name' => 'Founder Sync',
+        'slug' => 'founder-sync',
+        'visibility' => WorkspaceChat::VISIBILITY_PRIVATE,
+    ]);
+    WorkspaceChatParticipant::factory()->for($activeChat, 'chat')->create([
+        'user_id' => $user->getKey(),
+        'participant_type' => WorkspaceChatParticipant::TYPE_HUMAN,
+        'participant_key' => 'human:derek@katra.io',
+        'display_name' => 'Derek Bourgeois',
+    ]);
+    WorkspaceChatParticipant::factory()->for($activeChat, 'chat')->create([
+        'user_id' => null,
+        'participant_type' => WorkspaceChatParticipant::TYPE_HUMAN,
+        'participant_key' => 'human:morgan@katra.io',
+        'display_name' => 'Morgan Hale',
+    ]);
+    WorkspaceChatMessage::factory()->for($activeChat, 'chat')->create([
+        'sender_type' => WorkspaceChatMessage::SENDER_HUMAN,
+        'sender_key' => 'human:derek@katra.io',
+        'sender_name' => 'Derek Bourgeois',
+        'body' => 'Lock the private chat layer before we wire agents into it.',
+    ]);
+    WorkspaceChatMessage::factory()->for($activeChat, 'chat')->create([
+        'sender_type' => WorkspaceChatMessage::SENDER_HUMAN,
+        'sender_key' => 'human:morgan@katra.io',
+        'sender_name' => 'Morgan Hale',
+        'body' => 'Agreed. The workspace should own chats, not the other way around.',
+    ]);
 
     $currentConnection->forceFill([
         'active_workspace_id' => $activeWorkspace->getKey(),
+    ])->save();
+    $activeWorkspace->forceFill([
+        'active_chat_id' => $activeChat->getKey(),
     ])->save();
 
     InstanceConnection::factory()->for($user)->create([
@@ -76,8 +117,9 @@ test('the desktop shell exposes the connection-aware workspace shell', function 
         ->assertSee('Create chat')
         ->assertSee('Product Atlas')
         ->assertSee('General')
-        ->assertSee('Planner Agent')
-        ->assertSee('Research Model')
+        ->assertSee('Design Review')
+        ->assertSee('Founder Sync')
+        ->assertSee('Morgan Hale')
         ->assertSee('# general')
         ->assertSee('Connections')
         ->assertSee('Add a server')
@@ -101,15 +143,10 @@ test('the desktop shell exposes the connection-aware workspace shell', function 
         ->assertSee('Open')
         ->assertSee('Closed')
         ->assertSee('In review')
-        ->assertSee('Assign to agent')
-        ->assertSee('Assign')
-        ->assertSee('Choose an agent')
-        ->assertSee('Context Agent')
-        ->assertSee('Attach file')
-        ->assertSee('Toggle voice mode')
         ->assertSee('Send message')
-        ->assertSee('Message Product Atlas')
-        ->assertSee('Voice mode selected')
+        ->assertSee('Message Design Review')
+        ->assertSee('Lock the private chat layer before we wire agents into it.')
+        ->assertSee('Agreed. The workspace should own chats, not the other way around.')
         ->assertSee('Product Atlas is a workspace on this instance for conversations, tasks, and linked work.')
         ->assertSee('Derek Bourgeois')
         ->assertSee('derek@katra.io')
@@ -181,9 +218,30 @@ test('the desktop shell can render a saved server connection as the active conne
         'slug' => 'relay-launch',
         'summary' => 'Relay Launch is the active workspace on Relay Cloud for shared orchestration, worker presence, and linked team context.',
     ]);
+    $activeChat = WorkspaceChat::factory()->for($workspace, 'workspace')->create([
+        'name' => 'Ops Briefing',
+        'slug' => 'ops-briefing',
+        'kind' => WorkspaceChat::KIND_GROUP,
+        'visibility' => WorkspaceChat::VISIBILITY_PRIVATE,
+    ]);
+    WorkspaceChatParticipant::factory()->for($activeChat, 'chat')->create([
+        'user_id' => null,
+        'participant_type' => WorkspaceChatParticipant::TYPE_HUMAN,
+        'participant_key' => 'human:ops@relay.devoption.test',
+        'display_name' => 'Relay Operator',
+    ]);
+    WorkspaceChatMessage::factory()->for($activeChat, 'chat')->create([
+        'sender_type' => WorkspaceChatMessage::SENDER_HUMAN,
+        'sender_key' => 'human:ops@relay.devoption.test',
+        'sender_name' => 'Relay Operator',
+        'body' => 'Remote conversations stay private to this workspace and do not enter the shared graph.',
+    ]);
 
     $connection->forceFill([
         'active_workspace_id' => $workspace->getKey(),
+    ])->save();
+    $workspace->forceFill([
+        'active_chat_id' => $activeChat->getKey(),
     ])->save();
 
     actingAs($user)
@@ -194,10 +252,10 @@ test('the desktop shell can render a saved server connection as the active conne
         ->assertSee('Relay Cloud')
         ->assertSee('Connections')
         ->assertSee('Relay Launch')
+        ->assertSee('Ops Briefing')
         ->assertSee('# general')
-        ->assertSee('Ops Agent')
-        ->assertSee('Routing Agent')
         ->assertSee('Relay Operator')
         ->assertSee('ops@relay.devoption.test')
+        ->assertSee('Remote conversations stay private to this workspace and do not enter the shared graph.')
         ->assertSee('Signed in as ops@relay.devoption.test.');
 });

--- a/tests/Feature/InstanceConnectionManagementTest.php
+++ b/tests/Feature/InstanceConnectionManagementTest.php
@@ -3,6 +3,9 @@
 use App\Models\InstanceConnection;
 use App\Models\User;
 use App\Models\Workspace;
+use App\Models\WorkspaceChat;
+use App\Models\WorkspaceChatMessage;
+use App\Models\WorkspaceChatParticipant;
 use App\Support\Connections\InstanceConnectionManager;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\Client\Request as HttpRequest;
@@ -253,9 +256,30 @@ test('the shell uses the currently active connection profile for the session', f
         'name' => 'Relay Launch',
         'slug' => 'relay-launch',
     ]);
+    $chat = WorkspaceChat::factory()->for($workspace, 'workspace')->create([
+        'name' => 'Ops Briefing',
+        'slug' => 'ops-briefing',
+        'kind' => WorkspaceChat::KIND_GROUP,
+        'visibility' => WorkspaceChat::VISIBILITY_PRIVATE,
+    ]);
+    WorkspaceChatParticipant::factory()->for($chat, 'chat')->create([
+        'user_id' => null,
+        'participant_type' => WorkspaceChatParticipant::TYPE_AGENT,
+        'participant_key' => 'agent:ops-agent',
+        'display_name' => 'Ops Agent',
+    ]);
+    WorkspaceChatMessage::factory()->for($chat, 'chat')->create([
+        'sender_type' => WorkspaceChatMessage::SENDER_AGENT,
+        'sender_key' => 'agent:ops-agent',
+        'sender_name' => 'Ops Agent',
+        'body' => 'Relay Cloud keeps private chats scoped to the active workspace.',
+    ]);
 
     $connection->forceFill([
         'active_workspace_id' => $workspace->getKey(),
+    ])->save();
+    $workspace->forceFill([
+        'active_chat_id' => $chat->getKey(),
     ])->save();
 
     actingAs($user)->withSession([
@@ -267,7 +291,9 @@ test('the shell uses the currently active connection profile for the session', f
         ->assertSee('Relay Cloud')
         ->assertSee('Relay Launch')
         ->assertSee('# general')
+        ->assertSee('Ops Briefing')
         ->assertSee('Ops Agent')
+        ->assertSee('Relay Cloud keeps private chats scoped to the active workspace.')
         ->assertSee('Relay Ops')
         ->assertSee('ops@relay.devoption.test');
 });

--- a/tests/Feature/WorkspaceChatManagementTest.php
+++ b/tests/Feature/WorkspaceChatManagementTest.php
@@ -1,0 +1,133 @@
+<?php
+
+use App\Models\InstanceConnection;
+use App\Models\User;
+use App\Models\Workspace;
+use App\Models\WorkspaceChat;
+use App\Models\WorkspaceChatMessage;
+use App\Models\WorkspaceChatParticipant;
+use App\Support\Chats\WorkspaceChatManager;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\post;
+
+uses(RefreshDatabase::class);
+
+test('active chat resolution creates a default private group chat for the workspace', function () {
+    $user = User::factory()->create();
+    $connection = InstanceConnection::factory()->for($user)->currentInstance()->create();
+    $workspace = Workspace::factory()->for($connection)->create([
+        'active_chat_id' => null,
+    ]);
+
+    $chat = app(WorkspaceChatManager::class)->activeChatFor($workspace, $user, [
+        'name' => $user->name,
+        'email' => $user->email,
+        'initials' => 'KU',
+    ]);
+
+    expect($chat->name)->toBe('General chat')
+        ->and($chat->kind)->toBe(WorkspaceChat::KIND_GROUP)
+        ->and($chat->visibility)->toBe(WorkspaceChat::VISIBILITY_PRIVATE)
+        ->and($workspace->fresh()->active_chat_id)->toBe($chat->getKey())
+        ->and($chat->participants()->count())->toBe(1);
+});
+
+it('creates private workspace chats from the shell', function (string $kind) {
+    $user = User::factory()->create();
+    $connection = InstanceConnection::factory()->for($user)->currentInstance()->create([
+        'base_url' => 'https://katra.test',
+    ]);
+    $workspace = Workspace::factory()->for($connection)->create();
+
+    $workspace->forceFill([
+        'active_chat_id' => null,
+    ])->save();
+
+    actingAs($user)->withSession([
+        'instance_connection.active_id' => $connection->getKey(),
+    ]);
+
+    post(route('chats.store'), [
+        'chat_name' => $kind === WorkspaceChat::KIND_DIRECT ? 'Morgan' : 'Design Review',
+        'chat_kind' => $kind,
+    ])->assertRedirect(route('home'));
+
+    $chat = $workspace->fresh()->chats()->latest('id')->first();
+
+    expect($chat)->not()->toBeNull()
+        ->and($chat?->kind)->toBe($kind)
+        ->and($chat?->visibility)->toBe(WorkspaceChat::VISIBILITY_PRIVATE)
+        ->and($workspace->fresh()->active_chat_id)->toBe($chat?->getKey())
+        ->and($chat?->participants()->count())->toBe(1);
+})->with([
+    WorkspaceChat::KIND_DIRECT,
+    WorkspaceChat::KIND_GROUP,
+]);
+
+test('an authenticated user can activate another chat within the same workspace', function () {
+    $user = User::factory()->create();
+    $connection = InstanceConnection::factory()->for($user)->currentInstance()->create();
+    $workspace = Workspace::factory()->for($connection)->create();
+    $firstChat = WorkspaceChat::factory()->for($workspace, 'workspace')->create();
+    $secondChat = WorkspaceChat::factory()->for($workspace, 'workspace')->direct()->create();
+
+    $workspace->forceFill([
+        'active_chat_id' => $firstChat->getKey(),
+    ])->save();
+
+    actingAs($user);
+
+    post(route('chats.activate', $secondChat))
+        ->assertRedirect(route('home'));
+
+    expect($workspace->fresh()->active_chat_id)->toBe($secondChat->getKey());
+});
+
+test('an authenticated user can post a durable message into a workspace chat', function () {
+    $user = User::factory()->create([
+        'first_name' => 'Derek',
+        'last_name' => 'Bourgeois',
+        'name' => 'Derek Bourgeois',
+        'email' => 'derek@katra.io',
+    ]);
+    $connection = InstanceConnection::factory()->for($user)->currentInstance()->create();
+    $workspace = Workspace::factory()->for($connection)->create();
+    $chat = WorkspaceChat::factory()->for($workspace, 'workspace')->create([
+        'name' => 'Design Review',
+    ]);
+
+    actingAs($user);
+
+    post(route('chats.messages.store', $chat), [
+        'message_body' => 'Lock the private chat layer before we wire agents into it.',
+    ])->assertRedirect(route('home'));
+
+    $message = $chat->fresh()->messages()->first();
+
+    expect($message)->not()->toBeNull()
+        ->and($message?->sender_type)->toBe(WorkspaceChatMessage::SENDER_HUMAN)
+        ->and($message?->sender_name)->toBe('Derek Bourgeois')
+        ->and($message?->body)->toBe('Lock the private chat layer before we wire agents into it.')
+        ->and($workspace->fresh()->active_chat_id)->toBe($chat->getKey());
+});
+
+test('workspace chats stay private to their parent workspace', function () {
+    $user = User::factory()->create();
+    $connection = InstanceConnection::factory()->for($user)->currentInstance()->create();
+    $workspace = Workspace::factory()->for($connection)->create();
+    $otherWorkspace = Workspace::factory()->for($connection)->create();
+    $chat = WorkspaceChat::factory()->for($workspace, 'workspace')->create([
+        'visibility' => WorkspaceChat::VISIBILITY_PRIVATE,
+    ]);
+
+    WorkspaceChatParticipant::factory()->for($chat, 'chat')->create([
+        'participant_key' => 'human:derek@katra.io',
+        'display_name' => 'Derek Bourgeois',
+    ]);
+
+    expect($workspace->chats()->count())->toBe(1)
+        ->and($otherWorkspace->chats()->count())->toBe(0)
+        ->and($chat->visibility)->toBe(WorkspaceChat::VISIBILITY_PRIVATE);
+});


### PR DESCRIPTION
## Summary
- add private workspace-scoped chat persistence with durable messages and participants
- wire active chat selection and message posting into the desktop shell
- keep chats private to their parent workspace and out of the shared workspace graph

## Testing
- `'/Users/ibourgeois/Library/Application Support/Herd/bin/php84' artisan test --compact tests/Feature/WorkspaceChatManagementTest.php tests/Feature/DesktopShellTest.php tests/Feature/InstanceConnectionManagementTest.php`
- `'/Users/ibourgeois/Library/Application Support/Herd/bin/php84' artisan test --compact tests/Feature/WorkspaceChatManagementTest.php tests/Feature/DesktopShellTest.php tests/Feature/DesktopUiFeatureFlagTest.php tests/Feature/WorkspaceManagementTest.php tests/Feature/SurrealSchemaDriverTest.php`

Closes #134
